### PR TITLE
drop tracing dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,12 +342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,12 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,9 +566,6 @@ dependencies = [
  "serde_json",
  "sled",
  "tempfile",
- "tracing",
- "tracing-log",
- "tracing-subscriber",
  "walkdir",
  "zerocopy",
 ]
@@ -652,15 +628,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -759,73 +726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
-dependencies = [
- "cfg-if 1.0.0",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
-dependencies = [
- "ansi_term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,12 +742,6 @@ name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 sled = "0.34"
 tempfile = "3.2"
-tracing = "0.1.36"
-tracing-log = "0.1.3"
-tracing-subscriber = "0.3.15"
 walkdir = "2.3"
 zerocopy = "0.6"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,17 +20,13 @@ pub struct Cli {
 }
 
 impl Cli {
-    #[tracing::instrument(skip(self))]
     pub fn run(&self) -> Result<()> {
         let rbt: Rbt = match &self.load_from_json {
             Some(path) => Self::load_from_json(path).context("could not load from JSON")?,
             None => Self::load_from_roc(),
         };
 
-        tracing::info!(?rbt, "loaded");
-
         if self.dump_to_json {
-            tracing::info!("dumping to JSON, as reqested");
             println!(
                 "{}",
                 serde_json::to_string(&rbt).context("could not dump to JSON")?
@@ -51,22 +47,17 @@ impl Cli {
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug")]
     pub fn load_from_roc() -> Rbt {
-        tracing::trace!("running Roc program");
         let rbt = unsafe {
             let mut input = MaybeUninit::uninit();
             roc_init(input.as_mut_ptr());
             input.assume_init()
         };
 
-        tracing::trace!("converting Roc -> Rust");
         rbt.into()
     }
 
-    #[tracing::instrument(level = "debug")]
     pub fn load_from_json(path: &Path) -> Result<Rbt> {
-        tracing::trace!("loading from JSON");
         let file =
             File::open(path).with_context(|| format!("could not open {}", path.display()))?;
         let reader = BufReader::new(file);

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -21,13 +21,10 @@ pub struct Coordinator<'job> {
 }
 
 impl<'job> Coordinator<'job> {
-    #[tracing::instrument(skip(target_job))] // job is quite a bit of info for the log!
     pub fn add_target(&mut self, target_job: &'job rbt::Job) {
         let mut todo = vec![target_job];
 
         while let Some(job) = todo.pop() {
-            let _span = tracing::span!(tracing::Level::TRACE, "processing job").entered();
-
             // TODO: figure out the right hasher for our use case and use that instead
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
             job.hash(&mut hasher);
@@ -67,7 +64,6 @@ impl<'job> Coordinator<'job> {
         !self.blocked.is_empty() && !self.ready.is_empty()
     }
 
-    #[tracing::instrument(skip(self, runner))]
     pub fn run_next<R: Runner>(&mut self, runner: &R) -> Result<()> {
         let next = match self.ready.pop() {
             Some(id) => id,
@@ -84,10 +80,7 @@ impl<'job> Coordinator<'job> {
 
         for (blocked, blockers) in self.blocked.iter_mut() {
             if blockers.remove(&next) {
-                tracing::trace!(removed = ?next, ?blocked, "removed blocker");
-
                 if blockers.is_empty() {
-                    tracing::info!(ready = ?blocked, "new job ready to work");
                     self.ready.push(*blocked);
 
                     // TODO: it would be more performant to remove the

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -79,15 +79,13 @@ impl<'job> Coordinator<'job> {
             .context("could not run job")?;
 
         for (blocked, blockers) in self.blocked.iter_mut() {
-            if blockers.remove(&next) {
-                if blockers.is_empty() {
-                    self.ready.push(*blocked);
+            if blockers.remove(&next) && blockers.is_empty() {
+                self.ready.push(*blocked);
 
-                    // TODO: it would be more performant to remove the
-                    // newly-unblocked item from self.blocked, but there's
-                    // already a mutable borrow. Possibly rearrange the code
-                    // to do some mutable filtering thing.
-                }
+                // TODO: it would be more performant to remove the
+                // newly-unblocked item from self.blocked, but there's
+                // already a mutable borrow. Possibly rearrange the code
+                // to do some mutable filtering thing.
             }
         }
 

--- a/src/fake_runner.rs
+++ b/src/fake_runner.rs
@@ -5,9 +5,8 @@ use anyhow::Result;
 pub struct FakeRunner {}
 
 impl Runner for FakeRunner {
-    #[tracing::instrument]
     fn run(&self, job: &RunnableJob) -> Result<()> {
-        tracing::info!("fake runner \"running\" job");
+        eprintln!("running job: {:#?}", job);
 
         std::thread::sleep(std::time::Duration::from_millis(500));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,18 +89,8 @@ pub unsafe extern "C" fn roc_getppid() -> i32 {
 pub fn rust_main() -> isize {
     let cli = cli::Cli::parse();
 
-    let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
-        .with_max_level(tracing::Level::TRACE) // TODO: source log level from CLI args
-        .with_writer(std::io::stderr)
-        .finish();
-
-    tracing_log::LogTracer::init().expect("could not initialize log tracer");
-
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
-
     if let Err(problem) = cli.run() {
-        tracing::error!("{:?}", problem);
+        eprintln!("{:?}", problem);
         1
     } else {
         0


### PR DESCRIPTION
Adding tracing now is a bit much, especially when we don't need fine-grained span information for a while yet. It's too noisy, and it incurs a runtime cost. I looked into removing it (you can set maximum levels with feature flags, which removes a lot of information) but ended up thinking that it'd probably be better to just drop it and add spans or whatever later—`#[tracing::instrument]` would make that very easy.

Builds on, and should be merged after, #28