### PR TITLE
store outputs in a content-addressed store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +71,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -104,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +186,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -555,6 +588,7 @@ name = "roc-build"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake3",
  "byteorder",
  "clap",
  "digest",
@@ -672,6 +706,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,10 +620,12 @@ dependencies = [
  "digest",
  "itertools",
  "libc",
+ "log",
  "notify",
  "roc_std",
  "serde",
  "serde_json",
+ "simple_logger",
  "sled",
  "tempfile",
  "walkdir",
@@ -662,6 +690,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "simple_logger"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "166fea527c36d9b8a0a88c0c6d4c5077c699d9ffb5cf890b231a3f08c35f3d40"
+dependencies = [
+ "atty",
+ "colored",
+ "log",
+ "time",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -764,6 +805,24 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "time"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+blake3 = "1.3.1"
 byteorder = "1.4"
 clap = { version = "3.2.16", features = ["color", "suggestions", "unstable-v4", "env", "cargo", "derive"] }
 digest = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,12 @@ clap = { version = "3.2.16", features = ["color", "suggestions", "unstable-v4", 
 digest = "0.10"
 itertools = "0.10.3"
 libc = "0.2"
+log = { version = "0.4.17", features = ["max_level_trace", "release_max_level_info"] }
 notify = "4"
 roc_std = { path = "vendor/roc_std" }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
+simple_logger = { version = "2.2.0", features = ["stderr"] }
 sled = "0.34"
 tempfile = "3.2"
 walkdir = "2.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,7 @@ impl Cli {
         coordinator.add_target(rbt.f0.default);
 
         let runner: Box<dyn crate::coordinator::Runner> = if self.use_fake_runner {
+            log::info!("using fake runner");
             Box::new(crate::fake_runner::FakeRunner::default())
         } else {
             Box::new(crate::runner::Runner::new(self.root_dir.to_owned()))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,14 +24,14 @@ impl Cli {
 
         let store = Store::new(self.root_dir.join("store")).context("could not open store")?;
 
-        let mut coordinator = Coordinator::new(store);
+        let mut coordinator = Coordinator::new(self.root_dir.join("workspaces"), store);
         coordinator.add_target(rbt.f0.default);
 
         let runner: Box<dyn crate::coordinator::Runner> = if self.use_fake_runner {
             log::info!("using fake runner");
             Box::new(crate::fake_runner::FakeRunner::default())
         } else {
-            Box::new(crate::runner::Runner::new(self.root_dir.to_owned()))
+            Box::new(crate::runner::Runner)
         };
 
         while coordinator.has_outstanding_work() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ impl Cli {
     pub fn run(&self) -> Result<()> {
         let rbt = Self::load();
 
-        let store = Store::new(self.root_dir.join("store"));
+        let store = Store::new(self.root_dir.join("store")).context("could not open store")?;
 
         let mut coordinator = Coordinator::new(store);
         coordinator.add_target(rbt.f0.default);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::coordinator::Coordinator;
 use crate::glue;
+use crate::store::Store;
 use anyhow::{Context, Result};
 use clap::Parser;
 use core::mem::MaybeUninit;
@@ -14,20 +15,22 @@ pub struct Cli {
     use_fake_runner: bool,
 
     #[clap(long, default_value = ".rbt")]
-    isolator_root: PathBuf,
+    root_dir: PathBuf,
 }
 
 impl Cli {
     pub fn run(&self) -> Result<()> {
         let rbt = Self::load();
 
-        let mut coordinator = Coordinator::default();
+        let store = Store::new(self.root_dir.join("store"));
+
+        let mut coordinator = Coordinator::new(store);
         coordinator.add_target(rbt.f0.default);
 
         let runner: Box<dyn crate::coordinator::Runner> = if self.use_fake_runner {
             Box::new(crate::fake_runner::FakeRunner::default())
         } else {
-            Box::new(crate::runner::Runner::new(self.isolator_root.to_owned()))
+            Box::new(crate::runner::Runner::new(self.root_dir.to_owned()))
         };
 
         while coordinator.has_outstanding_work() {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -48,6 +48,8 @@ impl Coordinator {
             .get(&id)
             .context("had a bad job ID in Coordinator.ready")?;
 
+        log::debug!("preparing to run job {}", job.id);
+
         if self.store.for_job(&job).is_none() {
             runner.run(job).context("could not run job")?;
         } else {
@@ -70,6 +72,7 @@ impl Coordinator {
 
             let no_blockers_remaining = blockers.is_empty();
             if no_blockers_remaining {
+                log::debug!("unblocked {}", blocked);
                 newly_unblocked.push(*blocked)
             }
             !no_blockers_remaining

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -61,7 +61,7 @@ impl Coordinator {
             runner.run(job, &workspace).context("could not run job")?;
 
             self.store
-                .store_from_workspace(job, workspace.as_ref())
+                .store_from_workspace(job, workspace)
                 .context("could not store job output")?;
         } else {
             log::debug!("already had output of this job; skipping");

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -54,14 +54,14 @@ impl Coordinator {
 
         log::debug!("preparing to run job {}", job.id);
 
-        if self.store.for_job(&job).is_none() {
-            let workspace = Workspace::create(&self.workspace_root, &job)
+        if self.store.for_job(job).is_none() {
+            let workspace = Workspace::create(&self.workspace_root, job)
                 .with_context(|| format!("could not create workspace for job {}", job.id))?;
 
             runner.run(job, &workspace).context("could not run job")?;
 
             self.store
-                .store_from_workspace(&job, workspace.as_ref())
+                .store_from_workspace(job, workspace.as_ref())
                 .context("could not store job output")?;
         } else {
             log::debug!("already had output of this job; skipping");

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -48,8 +48,6 @@ impl Coordinator {
             .get(&id)
             .context("had a bad job ID in Coordinator.ready")?;
 
-        println!("{:#?}", &self.store.for_job(&job));
-
         runner.run(job).context("could not run job")?;
 
         // Now that we're done running the job, we update our bookkeeping to

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -72,34 +72,3 @@ impl Runner for Box<dyn Runner> {
         self.as_ref().run(job)
     }
 }
-
-/// Some parts of `glue::Job` do not have a meaningful ordering (for example,
-/// the order of output files) while some do (for example, the ordering of
-/// command arguments.) This hasher's job is to return the same value for a
-/// non-meaningful change, but change immediately for a meaningful one.
-///
-/// Note: this data structure is going to grow the ability to refer to other
-/// jobs as soon as it's possibly feasible. When that happens, a depth-first
-/// search through the tree rooted at `top_job` will probably suffice.
-fn hash_for_glue_job(top_job: &glue::Job) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-
-    let job = &top_job.f0;
-
-    // TODO: when we can get commands from other jobs, we need to hash the
-    // other tool instead of relying on the derived `Hash` trait for this,
-    // for the reasons in the top doc comment here.
-    job.command.hash(&mut hasher);
-
-    job.inputFiles
-        .iter()
-        .sorted()
-        .for_each(|input_file| input_file.hash(&mut hasher));
-
-    job.outputs
-        .iter()
-        .sorted()
-        .for_each(|output| output.hash(&mut hasher));
-
-    hasher.finish()
-}

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -1,16 +1,29 @@
 use crate::glue;
 use crate::job::{self, Job};
+use crate::store::Store;
 use anyhow::{Context, Result};
 use std::collections::{HashMap, HashSet};
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Coordinator {
+    store: Store,
+
     jobs: HashMap<job::Id, Job>,
     blocked: HashMap<job::Id, HashSet<job::Id>>,
     ready: Vec<job::Id>,
 }
 
 impl Coordinator {
+    pub fn new(store: Store) -> Self {
+        Coordinator {
+            store,
+
+            jobs: HashMap::default(),
+            blocked: HashMap::default(),
+            ready: Vec::default(),
+        }
+    }
+
     pub fn add_target(&mut self, top_job: glue::Job) {
         // Note: this data structure is going to grow the ability to refer to other
         // jobs as soon as it's possibly feasible. When that happens, a depth-first

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -64,7 +64,6 @@ impl Coordinator {
                 .store_from_workspace(&job, workspace.as_ref())
                 .context("could not store job output")?;
         } else {
-            // TODO: put this in a proper logging framework
             log::debug!("already had output of this job; skipping");
         }
 

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -52,7 +52,7 @@ impl Coordinator {
             runner.run(job).context("could not run job")?;
         } else {
             // TODO: put this in a proper logging framework
-            eprintln!("[INFO] already had job, skipping");
+            log::debug!("already had output of this job; skipping");
         }
 
         // Now that we're done running the job, we update our bookkeeping to

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -48,7 +48,12 @@ impl Coordinator {
             .get(&id)
             .context("had a bad job ID in Coordinator.ready")?;
 
-        runner.run(job).context("could not run job")?;
+        if self.store.for_job(&job).is_none() {
+            runner.run(job).context("could not run job")?;
+        } else {
+            // TODO: put this in a proper logging framework
+            eprintln!("[INFO] already had job, skipping");
+        }
 
         // Now that we're done running the job, we update our bookkeeping to
         // figure out what running that job just unblocked.

--- a/src/fake_runner.rs
+++ b/src/fake_runner.rs
@@ -1,12 +1,13 @@
 use crate::coordinator::Runner;
 use crate::job::Job;
+use crate::workspace::Workspace;
 use anyhow::Result;
 
 #[derive(Debug, Default)]
 pub struct FakeRunner {}
 
 impl Runner for FakeRunner {
-    fn run(&self, job: &Job) -> Result<()> {
+    fn run(&self, job: &Job, _workspace: &Workspace) -> Result<()> {
         log::info!("fake-running job {:?}", job);
 
         std::thread::sleep(std::time::Duration::from_millis(500));

--- a/src/fake_runner.rs
+++ b/src/fake_runner.rs
@@ -7,7 +7,7 @@ pub struct FakeRunner {}
 
 impl Runner for FakeRunner {
     fn run(&self, job: &Job) -> Result<()> {
-        eprintln!("running job: {:#?}", job);
+        log::info!("fake-running job {:?}", job);
 
         std::thread::sleep(std::time::Duration::from_millis(500));
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -26,10 +26,12 @@ impl From<&glue::Job> for Id {
         // for this.
         job.command.hash(&mut hasher);
 
-        job.inputFiles
-            .iter()
-            .sorted()
-            .for_each(|input_file| input_file.hash(&mut hasher));
+        // TODO: input file hashes need to change this hash. We cannot do that
+        // yet, so we cannot accept files yet!
+        debug_assert!(
+            job.inputFiles.is_empty(),
+            "we cannot handle input files in hashes yet"
+        );
 
         job.outputs
             .iter()

--- a/src/job.rs
+++ b/src/job.rs
@@ -15,6 +15,8 @@ impl From<&glue::Job> for Id {
     /// jobs as soon as it's feasible. When that happens, a depth-first search
     /// through the tree rooted at `top_job` will probably suffice.
     fn from(top_job: &glue::Job) -> Self {
+        // TODO: is this the best hash for this kind of data? Should we find
+        // a faster one?
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
         let job = &top_job.f0;

--- a/src/job.rs
+++ b/src/job.rs
@@ -3,7 +3,7 @@ use roc_std::{RocList, RocStr};
 use std::hash::{Hash, Hasher};
 use std::process::Command;
 
-#[derive(Debug, Eq, Hash, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Id(u64);
 
 impl From<&glue::Job> for Id {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub(crate) unsafe extern "C" fn roc_panic(c_ptr: *mut c_void, tag_id: u32) {
         0 => {
             let slice = CStr::from_ptr(c_ptr as *const c_char);
             let string = slice.to_str().unwrap();
-            eprintln!("Roc hit a panic: {}", string);
+            log::error!("Roc hit a panic: {}", string);
             std::process::exit(1);
         }
         _ => todo!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod glue;
 mod job;
 mod runner;
 mod store;
+mod workspace;
 
 use clap::Parser;
 use std::ffi::{c_void, CStr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,10 @@ pub unsafe extern "C" fn roc_getppid() -> i32 {
 pub fn rust_main() -> isize {
     let cli = cli::Cli::parse();
 
+    simple_logger::SimpleLogger::new()
+        .init()
+        .expect("failed to initialize logger");
+
     if let Err(problem) = cli.run() {
         eprintln!("{:?}", problem);
         1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod fake_runner;
 mod glue;
 mod job;
 mod runner;
+mod store;
 
 use clap::Parser;
 use std::ffi::{c_void, CStr};

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,24 +1,14 @@
 use crate::coordinator;
 use crate::job::Job;
+use crate::workspace::Workspace;
 use anyhow::{Context, Result};
-use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Default)]
-pub struct Runner {
-    root: PathBuf,
-}
-
-impl Runner {
-    pub fn new(root: PathBuf) -> Self {
-        Runner { root }
-    }
-}
+pub struct Runner;
 
 impl coordinator::Runner for Runner {
-    fn run(&self, job: &Job) -> Result<()> {
-        let workspace = Workspace::create(&self.root, job)?;
-
+    fn run(&self, job: &Job, workspace: &Workspace) -> Result<()> {
         debug_assert!(
             job.input_files.is_empty(),
             "we don't handle input files yet"
@@ -39,83 +29,6 @@ impl coordinator::Runner for Runner {
             Some(0) => (),
             Some(code) => anyhow::bail!("command failed with the exit code {code}"),
             None => anyhow::bail!("command failed with no exit code (maybe it was killed?)"),
-        }
-
-        let store = Store::create(&self.root, job)?;
-        store.take_outputs_from_workspace(job, workspace)?;
-
-        Ok(())
-    }
-}
-
-struct Workspace(PathBuf);
-
-impl Workspace {
-    fn create(root: &Path, job: &Job) -> Result<Self> {
-        let workspace = Workspace(root.join("workspaces").join(job.id.to_string()));
-
-        std::fs::create_dir_all(&workspace).context("could not create workspace")?;
-
-        Ok(workspace)
-    }
-
-    fn join<P: AsRef<Path>>(&self, other: P) -> PathBuf {
-        self.0.join(other)
-    }
-}
-
-impl Drop for Workspace {
-    fn drop(&mut self) {
-        if let Err(problem) = std::fs::remove_dir_all(&self.0) {
-            log::warn!("problem removing workspace dir: {}", problem);
-        };
-    }
-}
-
-impl AsRef<Path> for Workspace {
-    fn as_ref(&self) -> &Path {
-        &self.0
-    }
-}
-
-struct Store(PathBuf);
-
-impl Store {
-    fn create(root: &Path, job: &Job) -> Result<Self> {
-        let store = Store(root.join("builds").join(job.id.to_string()));
-
-        std::fs::create_dir_all(&store.0).context("could not create directory to store outputs")?;
-
-        Ok(store)
-    }
-
-    fn join<P: AsRef<Path>>(&self, other: P) -> PathBuf {
-        self.0.join(other)
-    }
-
-    fn take_outputs_from_workspace(&self, job: &Job, workspace: Workspace) -> Result<()> {
-        for output in &job.outputs {
-            let output_str = output.as_str();
-            let workspace_src = workspace.join(output_str);
-
-            let mut perms = std::fs::metadata(&workspace_src)
-                .with_context(|| {
-                    format!(
-                        "could not find build output `{}`. Did the build produce it?",
-                        output_str
-                    )
-                })?
-                .permissions();
-            perms.set_readonly(true);
-            std::fs::set_permissions(&workspace_src, perms)
-                .with_context(|| format!("could not set permissions on `{}`", output_str))?;
-
-            std::fs::rename(&workspace_src, self.join(output_str)).with_context(|| {
-                format!(
-                    "could not move build output `{}` to the output directory",
-                    workspace_src.display()
-                )
-            })?;
         }
 
         Ok(())

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -67,8 +67,7 @@ impl Workspace {
 impl Drop for Workspace {
     fn drop(&mut self) {
         if let Err(problem) = std::fs::remove_dir_all(&self.0) {
-            // TODO: this should eventually be a system log line that warns of the error
-            eprintln!("[WARNING] problem removing workspace dir: {:}", problem);
+            log::warn!("problem removing workspace dir: {}", problem);
         };
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -32,6 +32,10 @@ impl Store {
             Err(err) => return Err(err).context("could not open mapping from inputs to content"),
         };
 
+        if !root.exists() {
+            std::fs::create_dir_all(&root).context("could not create specified root")?;
+        }
+
         Ok(Store {
             root,
             inputs_to_content,

--- a/src/store.rs
+++ b/src/store.rs
@@ -128,7 +128,7 @@ impl Store {
             //////////////////////////////
             // Step 4: collect the file //
             //////////////////////////////
-            log::trace!("moving {} into colleciton path", &source.display());
+            log::trace!("moving {} into collection path", &source.display());
             let out = temp.path().join(&source);
             std::fs::rename(workspace.join(&source), &out).with_context(|| {
                 format!(

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,12 +1,41 @@
+use crate::job::{self, Job};
+use anyhow::{Context, Result};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// This struct manages all the levels of storage that we need in order to avoid
+/// doing as much work as possible. This mostly involves managing several layers
+/// of caches:
 #[derive(Debug)]
 pub struct Store {
     root: PathBuf,
+
+    // This is stored as JSON for now to avoid taking another dependency,
+    // but it'd be good for it to be a real database (or database table)
+    // eventually. SQLite or Sled or something
+    inputs_to_content: HashMap<job::Id, PathBuf>,
 }
 
 impl Store {
-    pub fn new(root: PathBuf) -> Self {
-        Store { root }
+    pub fn new(root: PathBuf) -> Result<Self> {
+        let inputs_to_content = match std::fs::File::open(&root.join("inputs_to_content.json")) {
+            Ok(file) => {
+                let reader = std::io::BufReader::new(file);
+                serde_json::from_reader(reader)
+                    .context("could not deserialize mapping from inputs to content")?
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => HashMap::default(),
+            Err(err) => return Err(err).context("could not open mapping from inputs to content"),
+        };
+
+        Ok(Store {
+            root,
+            inputs_to_content,
+        })
+    }
+
+    pub fn for_job(&self, job: &Job) -> Option<PathBuf> {
+        println!("{:#?}", job);
+        None
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -92,7 +92,9 @@ impl Store {
             // efficient (for SIMD reasons), but `std::io::copy` uses an 8KiB
             // buffer. Gonna have to do this by hand at some point to take
             // advantage of the algorithm's designed speed.
-            std::io::copy(&mut file, &mut hasher);
+            std::io::copy(&mut file, &mut hasher).with_context(|| {
+                format!("could not read `{}` to calculate hash", source.display())
+            })?;
 
             ///////////////////////////////////////////////
             // Step 3: make sure any parent paths exist  //

--- a/src/store.rs
+++ b/src/store.rs
@@ -170,7 +170,7 @@ impl Store {
             .context("could not move temporary collection dir into the store")?;
         Self::make_readonly(&final_location).context("could not make store path readonly")?;
 
-        self.associate_job_with_hash(&job, &final_hash)
+        self.associate_job_with_hash(job, &final_hash)
             .context("could not associate job with hash")
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,4 +1,5 @@
 use crate::job::{self, Job};
+use crate::workspace::Workspace;
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -49,7 +50,7 @@ impl Store {
             .map(|path| self.root.join(path))
     }
 
-    pub fn store_from_workspace(&mut self, job: &Job, workspace: &Path) -> Result<()> {
+    pub fn store_from_workspace(&mut self, job: &Job, workspace: Workspace) -> Result<()> {
         let mut hasher = blake3::Hasher::new();
         let temp = tempfile::Builder::new()
             .prefix(&format!("rbt-job-{}", job.id))

--- a/src/store.rs
+++ b/src/store.rs
@@ -42,8 +42,8 @@ impl Store {
         })
     }
 
-    pub fn for_job(&self, job: &Job) -> Option<PathBuf> {
-        todo!()
+    pub fn for_job(&self, job: &Job) -> Option<&PathBuf> {
+        self.inputs_to_content.get(&job.id)
     }
 
     pub fn store_from_workspace(&self, job: &Job, workspace: &Path) -> Result<()> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -22,9 +22,9 @@ pub struct Store {
 
 impl Store {
     pub fn new(root: PathBuf) -> Result<Self> {
-        let inputs_to_content = match std::fs::File::open(&root.join("inputs_to_content.json")) {
+        let inputs_to_content = match File::open(&root.join("inputs_to_content.json")) {
             Ok(file) => {
-                let reader = std::io::BufReader::new(file);
+                let reader = BufReader::new(file);
                 serde_json::from_reader(reader)
                     .context("could not deserialize mapping from inputs to content")?
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -43,8 +43,7 @@ impl Store {
     }
 
     pub fn for_job(&self, job: &Job) -> Option<PathBuf> {
-        println!("{:#?}", job);
-        None
+        todo!()
     }
 
     pub fn store_from_workspace(&self, job: &Job, workspace: &Path) -> Result<()> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,7 +1,11 @@
 use crate::job::{self, Job};
 use anyhow::{Context, Result};
+use itertools::Itertools;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Component, Path, PathBuf};
 
 /// This struct manages all the levels of storage that we need in order to avoid
 /// doing as much work as possible. This mostly involves managing several layers
@@ -37,5 +41,124 @@ impl Store {
     pub fn for_job(&self, job: &Job) -> Option<PathBuf> {
         println!("{:#?}", job);
         None
+    }
+
+    pub fn store_from_workspace(&self, job: &Job, workspace: &Path) -> Result<()> {
+        let mut hasher = blake3::Hasher::new();
+        let temp = tempfile::Builder::new()
+            .prefix(&format!("rbt-job-{}", job.id))
+            .tempdir()
+            .context("couldn't create temporary directory for hashing")?;
+
+        let mut output_dirs: HashSet<PathBuf> = HashSet::new();
+
+        for output in job.outputs.iter().sorted() {
+            let source = PathBuf::from(output.as_str());
+
+            ///////////////////////////////////////////////////
+            // Step 1: Validate that the path we got is safe //
+            ///////////////////////////////////////////////////
+            for component in source.components() {
+                match component {
+                    Component::Prefix(_) | Component::RootDir =>  anyhow::bail!(
+                        "Got `{}` as an output, but absolute paths are not allowed as outputs. Remove the absolute prefix to fix this!",
+                        source.display(),
+                    ),
+
+                    Component::ParentDir => anyhow::bail!(
+                        "Got `{}` as an output, but relative paths containing `..` are not allowed as inputs. Remove the `..` to fix this!",
+                        source.display(),
+                    ),
+
+                    Component::CurDir | Component::Normal(_) => (),
+                };
+            }
+
+            ////////////////////////////////////////////////////////////////
+            // Step 2: add the file content to the content-addressed hash //
+            ////////////////////////////////////////////////////////////////
+            let mut file = File::open(&workspace.join(output.as_str())).with_context(|| {
+                format!(
+                    "couldn't open `{}` for hashing. Did the build produce it?",
+                    output
+                )
+            })?;
+
+            // TODO: docs for Blake3 say that a 16 KiB buffer is the most
+            // efficient (for SIMD reasons), but `std::io::copy` uses an 8KiB
+            // buffer. Gonna have to do this by hand at some point to take
+            // advantage of the algorithm's designed speed.
+            std::io::copy(&mut file, &mut hasher);
+
+            ///////////////////////////////////////////////
+            // Step 3: make sure any parent paths exist  //
+            ///////////////////////////////////////////////
+            let mut ancestors: Vec<&Path> = source.ancestors().skip(1).collect();
+            ancestors.pop(); // we've made sure this is relative, so the first item is ""
+            ancestors.reverse(); // go `[a, a/b, a/b/c]` instead of `[a/b/c, a/b, a]`
+
+            for ancestor_path in ancestors {
+                let ancestor = ancestor_path.to_path_buf();
+
+                if output_dirs.contains(&ancestor) {
+                    continue;
+                }
+
+                std::fs::create_dir(temp.path().join(&ancestor)).with_context(|| {
+                    format!(
+                        "could not create ancestor `{}` for output `{}`",
+                        ancestor.display(),
+                        source.display(),
+                    )
+                })?;
+                output_dirs.insert(ancestor);
+            }
+
+            //////////////////////////////
+            // Step 4: collect the file //
+            //////////////////////////////
+            let out = temp.path().join(&source);
+            std::fs::rename(workspace.join(&source), &out).with_context(|| {
+                format!(
+                    "could not move `{}` from workspace to store",
+                    source.display()
+                )
+            })?;
+
+            Self::make_readonly(&out).with_context(|| {
+                format!(
+                    "could not make `{}` read-only after moving into store",
+                    out.display()
+                )
+            })?;
+        }
+
+        // Finish up by making sure everything is readonly and store it in the
+        // final location.
+        for dir in &output_dirs {
+            Self::make_readonly(&temp.path().join(&dir)).with_context(|| {
+                format!("could not make `{}` read-only in the store", dir.display(),)
+            })?;
+        }
+
+        let final_location = self.root.join(hasher.finalize().to_hex().to_string());
+
+        // important: at this point we need to take ownership of the tempdir so
+        // that it doesn't get automatically removed when it's dropped. We've
+        // so far avoided that to avoid leaving temporary directories laying
+        // around in case of errors.
+        std::fs::rename(temp.into_path(), &final_location)
+            .context("could not move temporary collection dir into the store")?;
+        Self::make_readonly(&final_location).context("could not make store path readonly")
+    }
+
+    fn make_readonly(path: &Path) -> Result<()> {
+        let mut perms = std::fs::metadata(&path)
+            .context("could not get file metadata")?
+            .permissions();
+
+        perms.set_readonly(true);
+
+        std::fs::set_permissions(&path, perms).context("could not set permissions")
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,12 @@
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct Store {
+    root: PathBuf,
+}
+
+impl Store {
+    pub fn new(root: PathBuf) -> Self {
+        Store { root }
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -83,6 +83,8 @@ impl Store {
             ////////////////////////////////////////////////////////////////
             // Step 2: add the file content to the content-addressed hash //
             ////////////////////////////////////////////////////////////////
+            hasher.update(output.as_bytes());
+
             let mut file = File::open(&workspace.join(output.as_str())).with_context(|| {
                 format!(
                     "couldn't open `{}` for hashing. Did the build produce it?",

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -12,6 +12,10 @@ impl Workspace {
 
         Ok(workspace)
     }
+
+    pub fn join<P: AsRef<Path>>(&self, other: P) -> PathBuf {
+        self.0.join(other)
+    }
 }
 
 impl Drop for Workspace {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,29 @@
+use crate::job::Job;
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+pub struct Workspace(PathBuf);
+
+impl Workspace {
+    pub fn create(root: &Path, job: &Job) -> Result<Self> {
+        let workspace = Workspace(root.join("workspaces").join(job.id.to_string()));
+
+        std::fs::create_dir_all(&workspace.0).context("could not create workspace")?;
+
+        Ok(workspace)
+    }
+}
+
+impl Drop for Workspace {
+    fn drop(&mut self) {
+        if let Err(problem) = std::fs::remove_dir_all(&self.0) {
+            log::warn!("problem removing workspace dir: {}", problem);
+        };
+    }
+}
+
+impl AsRef<Path> for Workspace {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}


### PR DESCRIPTION
That lets us avoid doing work, like so:

```
$ roc run examples/hello/rbt.roc
🔨 Rebuilding host...
2022-08-18T22:34:02.255Z DEBUG [host::coordinator] preparing to run job d2a0eee0ece469cb
2022-08-18T22:34:02.259Z TRACE [host::store] moving out into collection path
2022-08-18T22:34:02.259Z DEBUG [host::store] moving f8ccb17e33d1f54fdc0761c864ef8d5881430bc55e887e0647ffc951b96d8032 into store

$ roc run examples/hello/rbt.roc
🔨 Rebuilding host...
2022-08-18T22:34:11.889Z DEBUG [host::coordinator] preparing to run job d2a0eee0ece469cb
2022-08-18T22:34:11.889Z DEBUG [host::coordinator] already had output of this job; skipping
```

I know this code will need to be changed for this to work in parallel, but we need this logic anyway so I think that's OK for the moment.

Based on #32; merge that first!