### PR TITLE
make a nicer to_string for Job

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ impl Cli {
 
         let store = Store::new(self.root_dir.join("store")).context("could not open store")?;
 
-        let mut coordinator = Coordinator::new(&self.root_dir, store);
+        let mut coordinator = Coordinator::new(self.root_dir.to_path_buf(), store);
         coordinator.add_target(rbt.f0.default);
 
         let runner: Box<dyn crate::coordinator::Runner> = if self.use_fake_runner {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ impl Cli {
 
         let store = Store::new(self.root_dir.join("store")).context("could not open store")?;
 
-        let mut coordinator = Coordinator::new(self.root_dir.join("workspaces"), store);
+        let mut coordinator = Coordinator::new(&self.root_dir, store);
         coordinator.add_target(rbt.f0.default);
 
         let runner: Box<dyn crate::coordinator::Runner> = if self.use_fake_runner {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -64,7 +64,7 @@ impl Coordinator {
                 .store_from_workspace(job, workspace)
                 .context("could not store job output")?;
         } else {
-            log::debug!("already had output of job {}; skipping", &job);
+            log::debug!("already had output of job {}; skipping", job);
         }
 
         // Now that we're done running the job, we update our bookkeeping to

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -4,7 +4,7 @@ use crate::store::Store;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct Coordinator {
@@ -17,9 +17,9 @@ pub struct Coordinator {
 }
 
 impl Coordinator {
-    pub fn new(workspace_root: PathBuf, store: Store) -> Self {
+    pub fn new(workspace_root: &Path, store: Store) -> Self {
         Coordinator {
-            workspace_root,
+            workspace_root: workspace_root.to_path_buf(),
             store,
 
             jobs: HashMap::default(),

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -4,7 +4,7 @@ use crate::store::Store;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result};
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct Coordinator {
@@ -17,9 +17,9 @@ pub struct Coordinator {
 }
 
 impl Coordinator {
-    pub fn new(workspace_root: &Path, store: Store) -> Self {
+    pub fn new(workspace_root: PathBuf, store: Store) -> Self {
         Coordinator {
-            workspace_root: workspace_root.to_path_buf(),
+            workspace_root,
             store,
 
             jobs: HashMap::default(),

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -52,7 +52,7 @@ impl Coordinator {
             .get(&id)
             .context("had a bad job ID in Coordinator.ready")?;
 
-        log::debug!("preparing to run job {}", job.id);
+        log::debug!("preparing to run job {}", job);
 
         if self.store.for_job(job).is_none() {
             let workspace = Workspace::create(&self.workspace_root, job)
@@ -64,7 +64,7 @@ impl Coordinator {
                 .store_from_workspace(job, workspace)
                 .context("could not store job output")?;
         } else {
-            log::debug!("already had output of this job; skipping");
+            log::debug!("already had output of job {}; skipping", &job);
         }
 
         // Now that we're done running the job, we update our bookkeeping to

--- a/src/fake_runner.rs
+++ b/src/fake_runner.rs
@@ -8,7 +8,7 @@ pub struct FakeRunner {}
 
 impl Runner for FakeRunner {
     fn run(&self, job: &Job, _workspace: &Workspace) -> Result<()> {
-        log::info!("fake-running job {:}", job);
+        log::info!("fake-running job {}", job);
 
         std::thread::sleep(std::time::Duration::from_millis(500));
 

--- a/src/fake_runner.rs
+++ b/src/fake_runner.rs
@@ -8,7 +8,7 @@ pub struct FakeRunner {}
 
 impl Runner for FakeRunner {
     fn run(&self, job: &Job, _workspace: &Workspace) -> Result<()> {
-        log::info!("fake-running job {:?}", job);
+        log::info!("fake-running job {:}", job);
 
         std::thread::sleep(std::time::Duration::from_millis(500));
 


### PR DESCRIPTION
log output now looks like `d2a0eee0ece469cb (bash -c "echo 'Hello, World!' > out")` instead of a debug struct of the whole job.

Also fixes a configuration bug where we were joining to the workspace directory twice (so making `.rbt/workspaces/workspaces`.)

Based on #34; merge that first!