### PR TITLE
use xxhash instead of the default hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
  "sled",
  "tempfile",
  "walkdir",
+ "xxhash-rust",
  "zerocopy",
 ]
 
@@ -973,6 +974,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074914ea4eec286eb8d1fd745768504f420a1f7b7919185682a4a267bed7d2e7"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ simple_logger = { version = "2.2.0", features = ["stderr"] }
 sled = "0.34"
 tempfile = "3.2"
 walkdir = "2.3"
+xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 zerocopy = "0.6"
 
 [lib]

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -10,6 +10,7 @@ use std::hash::{Hash, Hasher};
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::time::SystemTime;
+use xxhash_rust::xxh3::Xxh3;
 
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::MetadataExt;
@@ -271,7 +272,7 @@ struct PathMetaKey {
 
 impl From<&PathMetaKey> for u64 {
     fn from(key: &PathMetaKey) -> Self {
-        let mut hasher = std::collections::hash_map::DefaultHasher::default();
+        let mut hasher = Xxh3::new();
         key.hash(&mut hasher);
         hasher.finish()
     }

--- a/src/job.rs
+++ b/src/job.rs
@@ -7,6 +7,7 @@ use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 use std::path::{Component, PathBuf};
 use std::process::Command;
+use xxhash_rust::xxh3::Xxh3;
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Id(u64);
@@ -29,9 +30,7 @@ impl Job {
     pub fn from_glue(job: glue::Job, path_to_hash: &HashMap<PathBuf, String>) -> Result<Self> {
         let unwrapped = job.into_Job();
 
-        // TODO: is this the best hash for this kind of data? Should we find
-        // a faster one?
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let mut hasher = Xxh3::new();
 
         // TODO: when we can get commands from other jobs, we need to hash the
         // other tool and job instead of relying on the derived `Hash` trait

--- a/src/job.rs
+++ b/src/job.rs
@@ -147,6 +147,7 @@ pub fn sanitize_file_path(roc_str: &RocStr) -> Result<PathBuf> {
     Ok(sanitized)
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
     use roc_std::RocList;


### PR DESCRIPTION
Should be both faster and more stable (the Rust docs say not to depend on the output of the default hasher.)

Based on #41; review/merge that first

Fixes #38 