### PR TITLE
Rearrange hash key responsibilities

### DIFF
--- a/docs/internals/how-we-determine-when-to-run-jobs.md
+++ b/docs/internals/how-we-determine-when-to-run-jobs.md
@@ -1,0 +1,71 @@
+# How We Determine When to Run Jobs
+
+rbt tries to avoid unnecessary re-runs of jobs whenever possible using a layered approach.
+
+Here's a quick summary about how the process works.
+Afterwards, we'll go into more detail about each stage.
+
+1. Each job produces a cache key from its fields (command, args, environment, etc.)
+2. rbt's coordinator module adds information about input files and jobs to the key.
+3. If we have an output path for the combined key, we skip the build.
+4. Otherwise, we run the build and store a content-addressed hash.
+
+## Job Hashes
+
+`Job` definitions create the first level of cache key by hashing the information it has direct access to: things like command and args or input file names.
+
+Wherever possible, these keys avoid ordering or duplication: for example, the input file set `["a", "b"]` is not going to produce a different build just by being `["b", "a"]` or `["a", "b", "a"]`, so we'll treat that field as a set.
+Note that not all these validations are possible to enforce in the Roc API, but for those that will become possible (e.g. accepting sets directly instead of lists) we plan to break the API in releases before 1.0.0.
+
+It's important that `Job` does not do any filesystem operations when calculating this key.
+Multiple jobs reading and hashing the same configuration file (for example) will create a lot of unnecessary work.
+
+We do, however, include the paths to inputs.
+For example, what if we include `["a", "b"]` but then "b" later moves to "c" but has the same contents?
+If we did not include the path change, the cache key would not change and the build might not be re-run.
+(Although re-run might not be *strictly* necessary in this case, but rbt doesn't have enough information about the toolchains in your build to know this!)
+
+## Input Hashes
+
+Once we have a base hash for a `Job`, rbt collects all the files for all jobs, deduplicates paths, and fetches content hashes.
+
+We avoid some work here, too, by looking first at metadata about the files before calculating their hashes.
+
+Once we have that key, we look up the file hash in a persistent map.
+If we have the hash, great!
+We add it to the execution key and move on.
+
+Otherwise, we calculate a hash of the file's contents (currently using [BLAKE3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3)) and store it in the persistent map.
+
+<!-- aspirational as of 2022-09-02 -->
+We also add the content-address store paths of the jobs the current job depends on at this point.
+(See below for how we define those paths.)
+
+### A note on metadata vs hashing (and why we use both)
+
+Older build systems (like Make) use only the last-modified time (herinafter mtime) of the file.
+Newer build systems (like Shake) can be configured to use only hash.
+We use both, and lots of other filesystem metadata besides.
+Why is that?
+
+First of all, mtime comparisons causes problems in unintuitive ways ([as documented by Avery Pennarun](https://apenwarr.ca/log/20181113)).
+To sum up: you can't safely assume that mtime will only increase, or increase in a way that's always reliable to know if you need to rebuild.
+
+You can get a pretty good idea by combining mtime with other information, though!
+For example, if a file's length changed then you definitely need to rebuild.
+We look at more than just that, though: in addition to length and mtime (calculated on all systems), we also read the inode number, permissions, UID, and GID on Unix-family systems (e.g. Linux and macOS.)
+
+"Add more metadata" is good enough to avoid the problem of not rebuilding when a file changes, but we can still get unnecessary rebuilds when the file metadata changes without the content changing (e.g. `touch -m some-file`.)
+To avoid this and be able to skip as many rebuilds as possible, we also hash all the files.
+It would be unacceptably slow to recalculate hashes for every file, though, so we cache them according to a key derived from the metadata.
+
+This means making a bit of a tradeoff on flexibility, however: we can't rely on builds reliably producing side effects (e.g. uploading a built artifact to some store.)
+However, rbt tries to avoid uncontrolled side-effecty behavior in general, so this is OK for us!
+
+## Execution and the Output Store
+
+We store all the output of builds in a [content-addressed store (CAS)](https://en.wikipedia.org/wiki/Content-addressable_storage).
+As the final step before running a job, we check in a mapping between job keys and CAS.
+If we already have a store path, we assume that the build would produce the same output and skip running it.
+
+If we don't have a store path for the current hash, we run the build and hash the content to get a CAS path, store it, and move on to the next job!

--- a/docs/internals/how-we-determine-when-to-run-jobs.md
+++ b/docs/internals/how-we-determine-when-to-run-jobs.md
@@ -1,45 +1,37 @@
 # How We Determine When to Run Jobs
 
-rbt tries to avoid unnecessary re-runs of jobs whenever possible using a layered approach.
+rbt tries to avoid unnecessary re-runs of jobs whenever possible.
+To do this, we manage several levels of caches.
 
 Here's a quick summary about how the process works.
 Afterwards, we'll go into more detail about each stage.
 
-1. Each job produces a cache key from its fields (command, args, environment, etc.)
+1. Each job produces a cache key from its local fields (command, args, environment, etc.)
 2. rbt's coordinator module adds information about input files and jobs to the key.
 3. If we have an output path for the combined key, we skip the build.
 4. Otherwise, we run the build and store a content-addressed hash.
 
 ## Job Hashes
 
-`Job` definitions create the first level of cache key by hashing the information it has direct access to: things like command and args or input file names.
+`Job` definitions create the first level of cache key by hashing the information it can get without doing I/O: command, args, input file names, etc.
 
 Wherever possible, these keys avoid ordering or duplication: for example, the input file set `["a", "b"]` is not going to produce a different build just by being `["b", "a"]` or `["a", "b", "a"]`, so we'll treat that field as a set.
-Note that not all these validations are possible to enforce in the Roc API, but for those that will become possible (e.g. accepting sets directly instead of lists) we plan to break the API in releases before 1.0.0.
+Note that not all validations are possible to enforce in the Roc API, but for those that will become possible (e.g. accepting sets directly instead of lists) we plan to break the API in releases before 1.0.0.
 
-It's important that `Job` does not do any filesystem operations when calculating this key.
-Multiple jobs reading and hashing the same configuration file (for example) will create a lot of unnecessary work.
-
-We do, however, include the paths to inputs.
-For example, what if we include `["a", "b"]` but then "b" later moves to "c" but has the same contents?
+It's important that `Job` does not do any filesystem operations when calculating this key, since multiple jobs reading and hashing the same configuration file (for example) would create a lot of unnecessary work.
+The coordinator takes care of that work instead.
+We do, however, include the paths of file inputs and outputs, and then names of job inputs.
+For example, what if we include `["a", "b"]`, then "b" moves to "c" but has the same contents?
 If we did not include the path change, the cache key would not change and the build might not be re-run.
 (Although re-run might not be *strictly* necessary in this case, but rbt doesn't have enough information about the toolchains in your build to know this!)
 
 ## Input Hashes
 
-Once we have a base hash for a `Job`, rbt collects all the files for all jobs, deduplicates paths, and fetches content hashes.
+At the start of an rbt build, we collect all the files for all jobs and deduplicate their paths.
+For each path, we try to find the hash in a store (the key is metadata about the file.)
+If we don't have the hash, we calculate it using [BLAKE3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3).
 
-We avoid some work here, too, by looking first at metadata about the files before calculating their hashes.
-
-Once we have that key, we look up the file hash in a persistent map.
-If we have the hash, great!
-We add it to the execution key and move on.
-
-Otherwise, we calculate a hash of the file's contents (currently using [BLAKE3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3)) and store it in the persistent map.
-
-<!-- aspirational as of 2022-09-02 -->
-We also add the content-address store paths of the jobs the current job depends on at this point.
-(See below for how we define those paths.)
+Then, for each `Job`, we produce a final key by combining the input hashes of all the files and content-addresseable store paths of input jobs (see below) with the job's base key.
 
 ### A note on metadata vs hashing (and why we use both)
 
@@ -59,8 +51,8 @@ We look at more than just that, though: in addition to length and mtime (calcula
 To avoid this and be able to skip as many rebuilds as possible, we also hash all the files.
 It would be unacceptably slow to recalculate hashes for every file, though, so we cache them according to a key derived from the metadata.
 
-This means making a bit of a tradeoff on flexibility, however: we can't rely on builds reliably producing side effects (e.g. uploading a built artifact to some store.)
-However, rbt tries to avoid uncontrolled side-effecty behavior in general, so this is OK for us!
+This means making a bit of a tradeoff on flexibility: we can't rely on builds reliably producing side effects (e.g. uploading a built artifact to some store.)
+However, rbt tries to avoid uncontrolled side-effecting behavior in general, so this is OK for us!
 
 ## Execution and the Output Store
 

--- a/docs/internals/how-we-determine-when-to-run-jobs.md
+++ b/docs/internals/how-we-determine-when-to-run-jobs.md
@@ -1,35 +1,37 @@
 # How We Determine When to Run Jobs
 
 rbt tries to avoid re-running jobs it has seen before.
-To do this, we manage several levels of caches.
+To do this, we assume that builds are reproducible and keep track of which jobs produce which files.
+If we already have the output files for some build configuration, we just reuse them instead of rebuilding!
 
-Here's a quick summary about how the process works.
-Afterwards, we'll go into more detail about each stage.
+## Caches
 
-1. Each job produces a cache key from its local fields (command, args, environment, etc.)
-2. rbt's coordinator module adds information about input files and jobs to the key.
-3. If we have an output path for the combined key, we skip the build.
-4. Otherwise, we run the build and hash and store the output.
+To manage rebuild logic, we keep several levels of caches.
+Here's how they work:
 
-## Job Hashes
+### Level 1: Job Keys
 
-`Job` definitions create a cache key by hashing the information they can get without doing I/O: command, args, input file names, etc.
-
-Wherever possible, these keys avoid ordering or duplication: for example, the input files `["a", "b"]` are not going to produce a different build just by being `["b", "a"]` or `["a", "b", "a"]`, so we'll treat that field as a set.
-(Note that we'll likely change this field to be an actual set before 1.0.0!)
-
+`Job` definitions create a cache key by hashing their configuration.
+That means we use all the information from the command, args, input file names, etc.
 It's important that `Job` does not do any filesystem operations when calculating this key, since multiple jobs reading and hashing the same configuration file (for example) would be a lot of duplicated work.
-We do, however, include the paths of file inputs and outputs and the names of job inputs so we can track file moves that should cause rebuilds.
 
-## Input Hashes
+### Level 2: Job Keys + Input File Hashes
 
 At the start of an rbt build, we collect all the files for all jobs and deduplicate their paths.
-For each path, we get metadata about the file (details below) and use it to look up the file's content hash in a persistent store.
+For each path, we get metadata about the file and use it to look up the file's content hash in a persistent store.
 If we don't have the hash, we calculate and store it using [BLAKE3](https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE3).
 
-Then, for each `Job`, we produce a final key by combining the input hashes of all the files and content-addresseable store paths of input jobs (see below) with the job's base key.
+Then, for each `Job`, we produce a final key by combining the input hashes of all the files and content-addressable store paths of input jobs (see below) with the job's base key.
 
-### A note on metadata vs hashing (and why we use both)
+### Level 3: Execution and the Output Store
+
+We store all the output of builds in a [content-addressable store (CAS)](https://en.wikipedia.org/wiki/Content-addressable_storage).
+As the final step before running a job, we check in a mapping between job+hash keys and store paths.
+If we already have a store path, we assume that the build would produce the same output and skip running it.
+
+When a build succeeds, we hash and store the content in the CAS store for use in the next run.
+
+## A note on metadata vs hashing (and why we use both)
 
 Older build systems (like Make) use only the last-modified time (herinafter mtime) of the file.
 Newer build systems (like Shake) can be configured to use only hash.
@@ -40,20 +42,12 @@ First of all, mtime comparisons causes problems in unintuitive ways ([as documen
 To sum up: you can't safely assume that mtime will only increase, or increase in a way that's always reliable to know if you need to rebuild.
 
 You can get a pretty good idea by combining mtime with other information, though!
-For example, if a file's length changed then you definitely need to rebuild.
+For example, we definitely need to rebuild if a file's length changed.
 We look at more than just that, though: in addition to length and mtime (calculated on all systems), we also read the inode number, permissions, UID, and GID on Unix-family systems (e.g. Linux and macOS.)
 
 "Add more metadata" is good enough to avoid the problem of not rebuilding when a file changes, but we can still get unnecessary rebuilds when the file metadata changes without the content changing (e.g. `touch -m some-file`.)
-To avoid this and be able to skip as many rebuilds as possible, we also hash all the files.
-It would be unacceptably slow to recalculate hashes for every file, though, so we cache them according to a key derived from the metadata.
+To avoid this (and be able to skip as many rebuilds as possible) we also hash all the files.
+It would be unacceptably slow to recalculate hashes for file on every run, though, so we cache them according to a key derived from the metadata.
 
 This means making a bit of a tradeoff on flexibility: we can't rely on builds reliably producing side effects (e.g. uploading a built artifact to some store.)
 However, rbt tries to avoid uncontrolled side-effecting behavior in general, so this is OK for us!
-
-## Execution and the Output Store
-
-We store all the output of builds in a [content-addressed store (CAS)](https://en.wikipedia.org/wiki/Content-addressable_storage).
-As the final step before running a job, we check in a mapping between job keys and CAS.
-If we already have a store path, we assume that the build would produce the same output and skip running it.
-
-If we don't have a store path for the current hash, we run the build and hash the content to get a CAS path, store it, and move on to the next job!

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -197,9 +197,9 @@ pub struct Coordinator {
     path_to_hash: HashMap<PathBuf, String>,
 
     // which jobs should run when?
-    jobs: HashMap<job::Key, Job>,
-    blocked: HashMap<job::Key, HashSet<job::Key>>,
-    ready: Vec<job::Key>,
+    jobs: HashMap<job::Key<job::Base>, Job>,
+    blocked: HashMap<job::Key<job::Base>, HashSet<job::Key<job::Base>>>,
+    ready: Vec<job::Key<job::Base>>,
 }
 
 impl Coordinator {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -82,9 +82,11 @@ impl Builder {
 
             path_to_hash: HashMap::with_capacity(input_files.len()),
 
-            jobs: HashMap::default(),
+            // On capacities: we'll have at least as many jobs as we have targets,
+            // each of which will have at least one leaf node.
+            jobs: HashMap::with_capacity(self.targets.len()),
             blocked: HashMap::default(),
-            ready: Vec::default(),
+            ready: Vec::with_capacity(self.targets.len()),
         };
 
         /////////////////////////////////////////////

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -159,8 +159,8 @@ impl Builder {
             // refer to other jobs as soon as it's possibly feasible. When
             // that happens, a depth-first search through the tree rooted at
             // `glue_job` will probably suffice.
-            let job = Job::from_glue(glue_job, &path_to_hash)
-                .context("could not convert glue job to actual job")?;
+            let job =
+                Job::from_glue(glue_job).context("could not convert glue job to actual job")?;
 
             coordinator.ready.push(job.id);
             coordinator.jobs.insert(job.id, job);

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -106,7 +106,7 @@ impl Builder {
 
             if meta.is_dir() {
                 anyhow::bail!(
-                    "One of your jobs specifies `{}`, a directory, as a dependency. I can only handle files.",
+                    "One of your jobs specifies `{}` as a dependency. It's a directory, but I can only handle files.",
                     input_file.display(),
                 )
             };

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -64,10 +64,10 @@ impl Builder {
             ready: Vec::default(),
         };
 
-        // We assume that there will be at least some overlap in inputs (e.g. many
-        // targets looking at the same config file.) That assumption means that
-        // it makes sense to deduplicate them before doing a bunch of duplicate
-        // filesystem operations.
+        // We assume that there will be at least some overlap in inputs (i.e. at
+        // least two targets needing the same file.) That assumption means that
+        // it makes sense to deduplicate them to avoid duplicating filesystem
+        // operations.
         let mut input_files: HashSet<PathBuf> = HashSet::new();
         for glue_job in &self.targets {
             for file in &glue_job.as_Job().inputFiles {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -37,6 +37,17 @@ impl Builder {
     }
 
     pub fn build(mut self) -> Result<Coordinator> {
+        // Here's the overview of what we're about to do: for each file in
+        // each target job, we're going to look at metadata for that file and
+        // use that metadata to look up the file's hash (if we don't have it
+        // already, we'll read the file and calculate it.) We'll use all those
+        // hashes to construct a mapping from path->hash that coordinator can
+        // use to determine which jobs need to be run or skipped once the build
+        // is running.
+        //
+        // For more higher-level explanation of what we're going for, refer
+        // to docs/internals/how-we-determine-when-to-run-jobs.md.
+
         // We're currently storing the mapping from PathMetaKey to content
         // hash as a JSON object, so we need to load it first thing. In the
         // longer term, we'll probably move to using some sort of KV store,

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -224,7 +224,7 @@ impl Coordinator {
         let mut key_builder = job::KeyBuilder::based_on(&job.base_key);
         for path in &job.input_files {
             match self.path_to_hash.get(path) {
-                Some(hash) => key_builder.add_file(&path, hash),
+                Some(hash) => key_builder.add_file(path, hash),
                 None => anyhow::bail!("`{}` was specified as a file dependency, but I didn't have a hash for it! This is a bug in rbt's coordinator, please file it!", path.display()),
             }
         }
@@ -238,7 +238,7 @@ impl Coordinator {
             runner.run(job, &workspace).context("could not run job")?;
 
             self.store
-                .store_from_workspace(key, &job, workspace)
+                .store_from_workspace(key, job, workspace)
                 .context("could not store job output")?;
         } else {
             log::debug!("already had output of job {}; skipping", job);

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -197,9 +197,9 @@ pub struct Coordinator {
     path_to_hash: HashMap<PathBuf, String>,
 
     // which jobs should run when?
-    jobs: HashMap<job::Id, Job>,
-    blocked: HashMap<job::Id, HashSet<job::Id>>,
-    ready: Vec<job::Id>,
+    jobs: HashMap<job::Key, Job>,
+    blocked: HashMap<job::Key, HashSet<job::Key>>,
+    ready: Vec<job::Key>,
 }
 
 impl Coordinator {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -162,6 +162,10 @@ impl Builder {
             let job =
                 Job::from_glue(glue_job).context("could not convert glue job to actual job")?;
 
+            // TODO: pushing to `ready` immediately is only reasonable when
+            // we don't have job inputs as dependencies, but we don't have that
+            // yet. This'll need to change when we do or we'll have some very
+            // broken runs!
             coordinator.ready.push(job.id);
             coordinator.jobs.insert(job.id, job);
         }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -48,9 +48,9 @@ impl Builder {
         // For more higher-level explanation of what we're going for, refer
         // to docs/internals/how-we-determine-when-to-run-jobs.md.
 
-        // We're currently storing the mapping from PathMetaKey to content
-        // hash as a JSON object, so we need to load it first thing. In the
-        // longer term, we'll probably move to using some sort of KV store,
+        // We're currently storing the mapping from PathMetaKey to content hash as
+        // a JSON object, so we need to load it before we can do anything else. In
+        // the longer term, we'll probably move to using some sort of KV store,
         // at which point this deserialization will just be opening the database.
         let file_hashes_path = self.workspace_root.join("file_hashes.json");
         let mut meta_to_hash: HashMap<u64, String> = match File::open(&file_hashes_path) {

--- a/src/job.rs
+++ b/src/job.rs
@@ -189,11 +189,8 @@ mod test {
             outputs: RocList::from_slice(&["ouput_file".into()]),
         });
 
-        let mut path_to_hash: HashMap<PathBuf, String> = HashMap::new();
-        path_to_hash.insert("input_file".into(), "hashhashhash".into());
+        let job = Job::from_glue(glue_job).unwrap();
 
-        let job = Job::from_glue(glue_job, &path_to_hash).unwrap();
-
-        assert_eq!(Key(9236546748343508395), job.id);
+        assert_eq!(Key(16382010323901725809), job.base_key);
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -10,9 +10,9 @@ use std::process::Command;
 use xxhash_rust::xxh3::Xxh3;
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
-pub struct Id(u64);
+pub struct Key(u64);
 
-impl Display for Id {
+impl Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:x}", self.0)
     }
@@ -20,7 +20,7 @@ impl Display for Id {
 
 #[derive(Debug)]
 pub struct Job {
-    pub id: Id,
+    pub id: Key,
     pub command: glue::CommandPayload,
     pub input_files: HashSet<PathBuf>,
     pub outputs: HashSet<PathBuf>,
@@ -64,7 +64,7 @@ impl Job {
         }
 
         Ok(Job {
-            id: Id(hasher.finish()),
+            id: Key(hasher.finish()),
             command: unwrapped.command.into_Command(),
             input_files,
             outputs,
@@ -170,6 +170,6 @@ mod test {
 
         let job = Job::from_glue(glue_job, &path_to_hash).unwrap();
 
-        assert_eq!(Id(9236546748343508395), job.id);
+        assert_eq!(Key(9236546748343508395), job.id);
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -215,6 +215,12 @@ mod test {
 
         let job = Job::from_glue(glue_job).unwrap();
 
-        assert_eq!(Key(16382010323901725809), job.base_key);
+        assert_eq!(
+            Key {
+                key: 16382010323901725809,
+                phantom: PhantomData
+            },
+            job.base_key
+        );
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -52,6 +52,7 @@ pub struct Final;
 /// we'd have to do I/O for (like file hashes.) For more on the architecture,
 /// see `docs/internals/how-we-determine-when-to-run-jobs.md`.
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct Key<Finality> {
     key: u64,
     phantom: PhantomData<Finality>,

--- a/src/job.rs
+++ b/src/job.rs
@@ -10,6 +10,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use xxhash_rust::xxh3::Xxh3;
 
+/// Conversion from a base key to a final one.
 pub struct KeyBuilder(Xxh3);
 
 impl KeyBuilder {
@@ -37,12 +38,19 @@ impl KeyBuilder {
     }
 }
 
+/// See docs on `Key`
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Deserialize)]
 pub struct Base;
 
+/// See docs on `Key`
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Deserialize)]
 pub struct Final;
 
+/// A cache key for a job. This has a phantom type parameter because we calculate
+/// cache keys over multipole stages. The first (corresponding to `Base`) is just
+/// the information passed in from a `glue::Job`. The second includes information
+/// we'd have to do I/O for (like file hashes.) For more on the architecture,
+/// see `docs/internals/how-we-determine-when-to-run-jobs.md`.
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Key<Finality> {
     key: u64,

--- a/src/job.rs
+++ b/src/job.rs
@@ -2,7 +2,7 @@ use crate::glue;
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use roc_std::RocStr;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 use std::path::{Component, PathBuf};
@@ -27,7 +27,7 @@ pub struct Job {
 }
 
 impl Job {
-    pub fn from_glue(job: glue::Job, path_to_hash: &HashMap<PathBuf, String>) -> Result<Self> {
+    pub fn from_glue(job: glue::Job) -> Result<Self> {
         let unwrapped = job.into_Job();
 
         let mut hasher = Xxh3::new();
@@ -42,11 +42,7 @@ impl Job {
             let path =
                 sanitize_file_path(path_str).context("got an unacceptable input file path")?;
 
-            match path_to_hash.get(&path) {
-                Some(hash) => hash.hash(&mut hasher),
-                None => anyhow::bail!("couldn't find a hash for `{}`", path.display()),
-            }
-
+            path.hash(&mut hasher);
             input_files.insert(path);
         }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -17,7 +17,7 @@ pub struct Store {
     // This is stored as JSON for now to avoid taking another dependency,
     // but it'd be good for it to be a real database (or database table)
     // eventually. SQLite or Sled or something
-    inputs_to_content: HashMap<job::Key, String>,
+    inputs_to_content: HashMap<job::Key<job::Final>, String>,
 }
 
 impl Store {
@@ -45,7 +45,7 @@ impl Store {
 
     /// If an output exists for a job, what is it? If we don't have a stored
     /// output for the job, return `None`.
-    pub fn for_job(&self, key: &job::Key) -> Option<PathBuf> {
+    pub fn for_job(&self, key: &job::Key<job::Final>) -> Option<PathBuf> {
         self.inputs_to_content
             .get(key)
             .map(|path| self.root.join(path))
@@ -67,7 +67,7 @@ impl Store {
     ///     the workspace root.)
     pub fn store_from_workspace(
         &mut self,
-        key: job::Key,
+        key: job::Key<job::Final>,
         job: &Job,
         workspace: Workspace,
     ) -> Result<()> {
@@ -91,7 +91,7 @@ impl Store {
         }
     }
 
-    fn associate_job_with_hash(&mut self, key: job::Key, hash: &str) -> Result<()> {
+    fn associate_job_with_hash(&mut self, key: job::Key<job::Final>, hash: &str) -> Result<()> {
         self.inputs_to_content.insert(key, hash.to_owned());
 
         let file = std::fs::File::create(self.root.join("inputs_to_content.json"))

--- a/src/store.rs
+++ b/src/store.rs
@@ -17,7 +17,7 @@ pub struct Store {
     // This is stored as JSON for now to avoid taking another dependency,
     // but it'd be good for it to be a real database (or database table)
     // eventually. SQLite or Sled or something
-    inputs_to_content: HashMap<job::Id, String>,
+    inputs_to_content: HashMap<job::Key, String>,
 }
 
 impl Store {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,4 +1,4 @@
-use crate::job::Job;
+use crate::job;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 pub struct Workspace(PathBuf);
 
 impl Workspace {
-    pub fn create(root: &Path, job: &Job) -> Result<Self> {
-        let workspace = Workspace(root.join("workspaces").join(job.id.to_string()));
+    pub fn create(root: &Path, key: &job::Key) -> Result<Self> {
+        let workspace = Workspace(root.join("workspaces").join(key.to_string()));
 
         std::fs::create_dir_all(&workspace.0).context("could not create workspace")?;
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 pub struct Workspace(PathBuf);
 
 impl Workspace {
-    pub fn create(root: &Path, key: &job::Key) -> Result<Self> {
+    pub fn create(root: &Path, key: &job::Key<job::Final>) -> Result<Self> {
         let workspace = Workspace(root.join("workspaces").join(key.to_string()));
 
         std::fs::create_dir_all(&workspace.0).context("could not create workspace")?;


### PR DESCRIPTION
I was driving the other day and sort of mulling over the architecture of the system, and realized that having `Job` totally own its key based on external data is only going to get more annoying when we add recursive dependencies. A simpler architecture would be to let the coordinator coordinate the right key all in one spot.

So where before we would ask Job to calculate the hash for both its direct fields and pass in a Dict of input file hashes, now we ask Job to calculate a key for only the direct fields, and then build on it to get the full hash.

I also went ahead and documented the approach! Should pair well with #46, although these PRs don't depend on each other.