### PR TITLE
run cargo build before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
       - name: cargo clippy
         uses: actions-rs/cargo@v1
         with:

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -7,13 +7,10 @@ fn test_hello_world() {
     let root = TempDir::new().unwrap();
 
     Command::new("roc")
-        .arg("build")
+        .arg("run")
         .arg("--linker=legacy")
-        .arg("examples/hello/rbt.roc")
-        .assert()
-        .success();
-
-    Command::new("./build")
+        .arg("rbt.roc")
+        .arg("--")
         .arg("--root-dir")
         .arg(root.path().display().to_string())
         .current_dir("examples/hello")


### PR DESCRIPTION
It looks like we were running out of memory yesterday. #52 fixed this, but by separating the build from the run step, which is not how rbt will be used right now. It looks like building the platform before testing gets around this while letting us do tests how we (currently) recommend people to run the tool.