### PR TITLE
add privacy to the API

### DIFF
--- a/Package-Config.roc
+++ b/Package-Config.roc
@@ -1,25 +1,9 @@
 platform "roc-lang/rbt"
-    requires {} { init : Rbt }
+    requires {} { init : Rbt.Rbt }
     exposes [Rbt]
     packages {}
-    imports []
+    imports [Rbt]
     provides [initForHost]
 
-initForHost : Rbt
+initForHost : Rbt.Rbt
 initForHost = init
-
-# TODO: once `roc glue` knows how to resolve them, these should move back
-# into Rbt.roc so we can stop copying the definitions over every time we make
-# a change!
-SystemToolPayload : { name : Str }
-Tool : [SystemTool SystemToolPayload]
-
-CommandPayload : { tool : Tool, args : List Str }
-Command : [Command CommandPayload]
-
-FileMapping : Str
-Input : [FromProjectSource (List FileMapping)]
-
-Job : [Job { command : Command, inputs : List Input, outputs : List Str }]
-
-Rbt : { default : Job }

--- a/Package-Config.roc
+++ b/Package-Config.roc
@@ -20,7 +20,6 @@ Command : [Command CommandPayload]
 FileMapping : Str
 Input : [FromProjectSource (List FileMapping)]
 
-JobPayload : { command : Command, inputs : List Input, outputs : List Str }
-Job : [Job JobPayload]
+Job : [Job { command : Command, inputs : List Input, outputs : List Str }]
 
 Rbt : { default : Job }

--- a/Rbt.roc
+++ b/Rbt.roc
@@ -45,10 +45,10 @@ Job := [Job { command : Command, inputs : List Input, outputs : List Str }]
 job : { command : Command, inputs : List Input, outputs : List Str } -> Job
 job = \config -> @Job (Job config)
 
-Rbt : { default : Job }
+Rbt := { default : Job }
 
 init : { default : Job } -> Rbt
-init = \rbt -> rbt
+init = \rbt -> @Rbt rbt
 
 tool : Job, Str -> Tool
 tool = \_, _ ->

--- a/Rbt.roc
+++ b/Rbt.roc
@@ -26,10 +26,10 @@ exec : Tool, List Str -> Command
 exec = \execTool, args ->
     @Command { tool: execTool, args }
 
-FileMapping : Str
+FileMapping := Str
 
 sourceFile : Str -> FileMapping
-sourceFile = \name -> name
+sourceFile = \name -> @FileMapping name
 
 Input := [FromProjectSource (List FileMapping)]
 

--- a/Rbt.roc
+++ b/Rbt.roc
@@ -20,12 +20,11 @@ systemTool : Str -> Tool
 systemTool = \name ->
     @Tool (SystemTool { name })
 
-CommandPayload : { tool : Tool, args : List Str }
-Command : [Command CommandPayload]
+Command := { tool : Tool, args : List Str }
 
 exec : Tool, List Str -> Command
 exec = \execTool, args ->
-    Command { tool: execTool, args }
+    @Command { tool: execTool, args }
 
 FileMapping : Str
 

--- a/Rbt.roc
+++ b/Rbt.roc
@@ -14,11 +14,11 @@ interface Rbt
 #     Tool : [ SystemTool { name : Str }, FromJob { name : Str, job : Job } ]
 #
 SystemToolPayload : { name : Str }
-Tool : [SystemTool SystemToolPayload]
+Tool := [SystemTool SystemToolPayload]
 
 systemTool : Str -> Tool
 systemTool = \name ->
-    SystemTool { name }
+    @Tool (SystemTool { name })
 
 CommandPayload : { tool : Tool, args : List Str }
 Command : [Command CommandPayload]
@@ -54,4 +54,4 @@ init = \rbt -> rbt
 tool : Job, Str -> Tool
 tool = \_, _ ->
     # FromJob { name, job }
-    SystemTool { name: "TODO" }
+    @Tool (SystemTool { name: "TODO" })

--- a/Rbt.roc
+++ b/Rbt.roc
@@ -31,12 +31,12 @@ FileMapping : Str
 sourceFile : Str -> FileMapping
 sourceFile = \name -> name
 
-Input : [FromProjectSource (List FileMapping)]
+Input := [FromProjectSource (List FileMapping)]
 
 # Add the given file to the job's workspace (the working directory where the
 # command is called.)
 projectFiles : List FileMapping -> Input
-projectFiles = \mappings -> FromProjectSource mappings
+projectFiles = \mappings -> @Input (FromProjectSource mappings)
 
 Job : [Job { command : Command, inputs : List Input, outputs : List Str }]
 

--- a/Rbt.roc
+++ b/Rbt.roc
@@ -38,12 +38,12 @@ Input := [FromProjectSource (List FileMapping)]
 projectFiles : List FileMapping -> Input
 projectFiles = \mappings -> @Input (FromProjectSource mappings)
 
-Job : [Job { command : Command, inputs : List Input, outputs : List Str }]
+Job := [Job { command : Command, inputs : List Input, outputs : List Str }]
 
 # TODO: these fields are all required until https://github.com/rtfeldman/roc/issues/1844 is fixed
 # TODO: destructuring is broken, see https://github.com/rtfeldman/roc/issues/2512
 job : { command : Command, inputs : List Input, outputs : List Str } -> Job
-job = \config -> Job config
+job = \config -> @Job (Job config)
 
 Rbt : { default : Job }
 

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -52,7 +52,7 @@ pub struct Rbt {
 #[repr(transparent)]
 #[derive(Clone, Eq, Ord, Hash, PartialEq, PartialOrd)]
 pub struct Job {
-    f0: JobPayload,
+    f0: R1,
 }
 
 #[cfg(any(
@@ -64,7 +64,7 @@ pub struct Job {
 ))]
 #[derive(Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
 #[repr(C)]
-pub struct JobPayload {
+pub struct R1 {
     pub command: Command,
     pub inputs: roc_std::RocList<Input>,
     pub outputs: roc_std::RocList<roc_std::RocStr>,
@@ -187,7 +187,7 @@ impl Job {
         target_arch = "x86_64"
     ))]
     /// A tag named Job, with the given payload.
-    pub fn Job(f0: JobPayload) -> Self {
+    pub fn Job(f0: R1) -> Self {
         Self { f0 }
     }
 
@@ -200,7 +200,7 @@ impl Job {
     ))]
     /// Since `Job` only has one tag (namely, `Job`),
     /// convert it to `Job`'s payload.
-    pub fn into_Job(self) -> JobPayload {
+    pub fn into_Job(self) -> R1 {
         self.f0
     }
 
@@ -213,7 +213,7 @@ impl Job {
     ))]
     /// Since `Job` only has one tag (namely, `Job`),
     /// convert it to `Job`'s payload.
-    pub fn as_Job(&self) -> &JobPayload {
+    pub fn as_Job(&self) -> &R1 {
         &self.f0
     }
 }

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -77,22 +77,9 @@ pub struct R1 {
     target_arch = "x86",
     target_arch = "x86_64"
 ))]
-#[repr(transparent)]
-#[derive(Clone, Eq, Ord, Hash, PartialEq, PartialOrd)]
-pub struct Command {
-    f0: CommandPayload,
-}
-
-#[cfg(any(
-    target_arch = "arm",
-    target_arch = "aarch64",
-    target_arch = "wasm32",
-    target_arch = "x86",
-    target_arch = "x86_64"
-))]
 #[derive(Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
 #[repr(C)]
-pub struct CommandPayload {
+pub struct Command {
     pub args: roc_std::RocList<roc_std::RocStr>,
     pub tool: Tool,
 }
@@ -228,59 +215,6 @@ impl core::fmt::Debug for Job {
     ))]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("Job::Job").field(&self.f0).finish()
-    }
-}
-
-impl Command {
-    #[cfg(any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "wasm32",
-        target_arch = "x86",
-        target_arch = "x86_64"
-    ))]
-    /// A tag named Command, with the given payload.
-    pub fn Command(f0: CommandPayload) -> Self {
-        Self { f0 }
-    }
-
-    #[cfg(any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "wasm32",
-        target_arch = "x86",
-        target_arch = "x86_64"
-    ))]
-    /// Since `Command` only has one tag (namely, `Command`),
-    /// convert it to `Command`'s payload.
-    pub fn into_Command(self) -> CommandPayload {
-        self.f0
-    }
-
-    #[cfg(any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "wasm32",
-        target_arch = "x86",
-        target_arch = "x86_64"
-    ))]
-    /// Since `Command` only has one tag (namely, `Command`),
-    /// convert it to `Command`'s payload.
-    pub fn as_Command(&self) -> &CommandPayload {
-        &self.f0
-    }
-}
-
-impl core::fmt::Debug for Command {
-    #[cfg(any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "wasm32",
-        target_arch = "x86",
-        target_arch = "x86_64"
-    ))]
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Command::Command").field(&self.f0).finish()
     }
 }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -207,7 +207,7 @@ mod test {
         // callers. Similarly, it might be inappropriate new optional fields in the
         // Roc API to contribute to the ID, since doing so would mean completely
         // re-running all build steps.
-        let glue_job = glue::Job::Job(glue::JobPayload {
+        let glue_job = glue::Job::Job(glue::R1 {
             command: glue::Command::Command(glue::CommandPayload {
                 tool: glue::Tool::SystemTool(glue::SystemToolPayload {
                     name: RocStr::from("bash"),

--- a/src/job.rs
+++ b/src/job.rs
@@ -67,7 +67,7 @@ impl<Finality> Display for Key<Finality> {
 #[derive(Debug)]
 pub struct Job {
     pub base_key: Key<Base>,
-    pub command: glue::CommandPayload,
+    pub command: glue::Command,
     pub input_files: HashSet<PathBuf>,
     pub outputs: HashSet<PathBuf>,
 }
@@ -116,7 +116,7 @@ impl Job {
                 key: hasher.finish(),
                 phantom: PhantomData,
             },
-            command: unwrapped.command.into_Command(),
+            command: unwrapped.command,
             input_files,
             outputs,
         })
@@ -208,12 +208,12 @@ mod test {
         // Roc API to contribute to the ID, since doing so would mean completely
         // re-running all build steps.
         let glue_job = glue::Job::Job(glue::R1 {
-            command: glue::Command::Command(glue::CommandPayload {
+            command: glue::Command {
                 tool: glue::Tool::SystemTool(glue::SystemToolPayload {
                     name: RocStr::from("bash"),
                 }),
                 args: RocList::from_slice(&["-c".into(), "Hello, World".into()]),
-            }),
+            },
             inputs: RocList::from_slice(&[glue::Input::FromProjectSource(RocList::from([
                 "input_file".into(),
             ]))]),


### PR DESCRIPTION
now that we can have private stuff (since `glue` can cross module boundaries) we can make all the types in the API private and only expose constructors! Safety!

Based off of #55; review and merge that first.