### PR TITLE
allow jobs to depend on jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
 
     timeout-minutes: 90
     env:

--- a/Rbt.roc
+++ b/Rbt.roc
@@ -1,5 +1,5 @@
 interface Rbt
-    exposes [Rbt, init, Job, job, Command, exec, Tool, tool, systemTool, projectFiles, sourceFile]
+    exposes [Rbt, init, Job, job, Command, exec, Tool, tool, systemTool, projectFiles, fromJob, Input, sourceFile]
     imports []
 
 # TODO: these are all out of order due to https://github.com/rtfeldman/roc/issues/1642. Once that's fixed, they should rearrange into the order in `exposes`
@@ -40,6 +40,10 @@ Input := [
 # command is called.)
 projectFiles : List FileMapping -> Input
 projectFiles = \mappings -> @Input (FromProjectSource mappings)
+
+# Add files from the given job to the current job's workspace.
+fromJob : Job, List FileMapping -> Input
+fromJob = \otherJob, mappings -> @Input (FromJob otherJob mappings)
 
 Job := [
     Job

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "roc": {
-        "branch": "main",
+        "branch": "i4077",
         "description": "Roc is a language for making delightful software.",
         "homepage": "https://roc-lang.org",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "19e790f3b707f2fc73088008b290ba486ff66802",
-        "sha256": "1jfcgcxifjsxbnwrakp02kkjj6d2fjcfmss1hcwb8bq758b59i55",
+        "rev": "efdcce3086c8fc359e86c7e0d771ea985d45912f",
+        "sha256": "0rzb2plprk42f0kx7gm75hsja8pcd4dbg2nxdzg0jxg2gzvnyzz1",
         "type": "tarball",
-        "url": "https://github.com/roc-lang/roc/archive/19e790f3b707f2fc73088008b290ba486ff66802.tar.gz",
+        "url": "https://github.com/roc-lang/roc/archive/efdcce3086c8fc359e86c7e0d771ea985d45912f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
   ];
 
   roc = pkgs.callPackage sources.roc {
-    cargoSha256 = "sha256-//Mv8twyFV7n6wlAQykn/BRkcg4jZ3G0ofVHp+Xtn1Y=";
+    cargoSha256 = "sha256-bq+s/X3/tIaNa3TAZo9k4/eqozt3y4wcYe9IMbDN0KE=";
   };
 in pkgs.mkShell {
   buildInputs = with pkgs;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ impl Cli {
         let store = Store::new(self.root_dir.join("store")).context("could not open store")?;
 
         let mut builder = coordinator::Builder::new(self.root_dir.to_path_buf(), store);
-        builder.add_target(&rbt.default);
+        builder.add_root(&rbt.default);
 
         let mut coordinator = builder
             .build()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ impl Cli {
         let store = Store::new(self.root_dir.join("store")).context("could not open store")?;
 
         let mut builder = coordinator::Builder::new(self.root_dir.to_path_buf(), store);
-        builder.add_target(rbt.default);
+        builder.add_target(&rbt.default);
 
         let mut coordinator = builder
             .build()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,7 @@ impl Cli {
                 println!(
                     "{}",
                     coordinator
-                        .store_path(&root)
+                        .store_path(root)
                         .context("could not get store path for root")?
                         .path()
                         .display()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,10 @@ use std::path::PathBuf;
 pub struct Cli {
     #[clap(long, default_value = ".rbt")]
     root_dir: PathBuf,
+
+    /// Only useful for testing at the moment
+    #[clap(long)]
+    print_root_output_paths: bool,
 }
 
 impl Cli {
@@ -30,6 +34,17 @@ impl Cli {
 
         while coordinator.has_outstanding_work() {
             coordinator.run_next(&runner).context("failed to run job")?;
+        }
+
+        if self.print_root_output_paths {
+            for root in coordinator.roots() {
+                println!(
+                    "{}",
+                    coordinator
+                        .store_path(&root)
+                        .context("could not get store path for root")?
+                )
+            }
         }
 
         Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,8 @@ impl Cli {
                     coordinator
                         .store_path(&root)
                         .context("could not get store path for root")?
+                        .path()
+                        .display()
                 )
             }
         }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -70,8 +70,13 @@ impl Builder {
         let mut input_files: HashSet<PathBuf> = HashSet::new();
         for glue_job in &self.targets {
             for input in &glue_job.as_Job().inputs {
-                for file in input.as_FromProjectSource() {
-                    input_files.insert(job::sanitize_file_path(file)?);
+                match input.discriminant() {
+                    glue::discriminant_U1::FromJob => todo!(),
+                    glue::discriminant_U1::FromProjectSource => {
+                        for file in unsafe { input.as_FromProjectSource() } {
+                            input_files.insert(job::sanitize_file_path(file)?);
+                        }
+                    }
                 }
             }
         }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -280,12 +280,9 @@ impl<'roc> Coordinator<'roc> {
 
         log::debug!("preparing to run job {}", job);
 
-        let final_key = job::KeyBuilder::final_key_based_on(
-            &job,
-            &self.path_to_hash,
-            &self.job_to_content_hash,
-        )
-        .context("could not calculate final cache key")?;
+        let final_key = job
+            .final_key(&self.path_to_hash, &self.job_to_content_hash)
+            .context("could not calculate final cache key")?;
 
         // build (or don't) based on the final key!
         match self

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -70,12 +70,9 @@ impl Builder {
         let mut input_files: HashSet<PathBuf> = HashSet::new();
         for glue_job in &self.targets {
             for input in &glue_job.as_Job().inputs {
-                match input.discriminant() {
-                    glue::discriminant_U1::FromJob => todo!(),
-                    glue::discriminant_U1::FromProjectSource => {
-                        for file in unsafe { input.as_FromProjectSource() } {
-                            input_files.insert(job::sanitize_file_path(file)?);
-                        }
+                if input.discriminant() == glue::discriminant_U1::FromProjectSource {
+                    for file in unsafe { input.as_FromProjectSource() } {
+                        input_files.insert(job::sanitize_file_path(file)?);
                     }
                 }
             }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -193,8 +193,7 @@ impl<'roc> Builder<'roc> {
         let mut glue_to_job_key: HashMap<&glue::Job, job::Key<job::Base>, Xxh3Builder> =
             HashMap::with_capacity_and_hasher(self.roots.len(), Xxh3Builder::new());
 
-        // TODO: use Xxh3Builder in the HashSet here
-        let mut job_deps: HashMap<&glue::Job, HashSet<&glue::Job>, Xxh3Builder> =
+        let mut job_deps: HashMap<&glue::Job, HashSet<&glue::Job, Xxh3Builder>, Xxh3Builder> =
             HashMap::with_hasher(Xxh3Builder::new());
 
         while let Some(next_glue_job) = to_descend_into.pop() {
@@ -207,7 +206,9 @@ impl<'roc> Builder<'roc> {
                     let job = unsafe { item.as_FromJob() }.0;
 
                     let entry = job_deps.entry(next_glue_job);
-                    entry.or_default().insert(&job);
+                    entry
+                        .or_insert_with(|| HashSet::with_capacity_and_hasher(1, Xxh3Builder::new()))
+                        .insert(&job);
 
                     to_descend_into.push(job);
                 });

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -278,6 +278,11 @@ impl<'roc> Coordinator<'roc> {
         log::debug!("preparing to run job {}", job);
 
         // figure out the final key based on the job's dependencies
+        //
+        // TODO: it feels like much of the code between here and `finalize`
+        //  would be better off living in KeyBuilder itself. It probably doesn't
+        //  need to have a builder pattern at all, in fact, just a regular
+        //  constructor.
         let mut key_builder = job::KeyBuilder::based_on(&job.base_key);
         for path in &job.input_files {
             match self.path_to_hash.get(path) {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -187,8 +187,7 @@ impl<'roc> Builder<'roc> {
         // walk that list in the opposite direction.
         //
         // `to_descend_into` tracks the depth-first search part of this scheme,
-        // and `to_convert` is where we write down the dependencies in root-to-
-        // leaf order.
+        // and `to_convert` tracks the dependencies in root-to-leaf order.
         let mut to_descend_into = self.roots.clone();
         let mut to_convert = Vec::with_capacity(self.roots.len());
 

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -239,6 +239,10 @@ impl<'roc> Builder<'roc> {
             coordinator.jobs.insert(job.base_key, job);
         }
 
+        // we couldn't track which roots were needed before because we didn't
+        // have the keys for those jobs. Now that we do, take a minute to
+        // populate the roots vec (which up until now has had the right capacity
+        // but no items.)
         for root in self.roots {
             coordinator.roots.push(
                 *glue_to_job_key

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -210,7 +210,7 @@ impl<'roc> Builder<'roc> {
                     let entry = job_deps.entry(next_glue_job);
                     entry
                         .or_insert_with(|| HashSet::with_capacity_and_hasher(1, Xxh3Builder::new()))
-                        .insert(&job);
+                        .insert(job);
 
                     to_descend_into.push(job);
                 });

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -209,7 +209,7 @@ impl<'roc> Builder<'roc> {
                     let entry = job_deps.entry(next_glue_job);
                     entry
                         .or_insert_with(|| HashSet::with_capacity_and_hasher(1, Xxh3Builder::new()))
-                        .insert(&job);
+                        .insert(job);
 
                     to_descend_into.push(job);
                 });

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -218,6 +218,13 @@ impl<'roc> Builder<'roc> {
         }
 
         while let Some(glue_job) = to_convert.pop() {
+            // multiple jobs can depend on the same job, but we only need to
+            // convert each job once.
+            if let Some(key) = glue_to_job_key.get(glue_job) {
+                log::trace!("already converted job {}", key);
+                continue;
+            }
+
             let job = job::Job::from_glue(glue_job, &glue_to_job_key)
                 .context("could not convert glue job into actual job")?;
 

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -309,7 +309,7 @@ impl<'roc> Coordinator<'roc> {
 
                 workspace
                     .set_up_files(job)
-                    .with_context(|| format!("could not set up workspaces files for {}", job))?;
+                    .with_context(|| format!("could not set up workspace files for {}", job))?;
 
                 runner.run(job, &workspace).context("could not run job")?;
 

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -252,7 +252,9 @@ pub struct Coordinator<'roc> {
     // caches
     path_to_hash: HashMap<PathBuf, String>,
 
-    // TODO: have more of a think about whether this mapping (from Base instead of Final) is safe
+    // note:  this mapping is only safe to use in the context of a single
+    // execution since a job's final key may change without the base key
+    // changing. Practically speaking, this just means you shouldn't store it!
     job_to_content_hash: HashMap<job::Key<job::Base>, store::Item>,
 
     // which jobs should run when?

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -217,7 +217,7 @@ impl<'roc> Builder<'roc> {
         }
 
         while let Some(glue_job) = to_convert.pop() {
-            let job = job::Job::from_glue(glue_job)
+            let job = job::Job::from_glue(glue_job, &glue_to_job_key)
                 .context("could not convert glue job into actual job")?;
 
             if let Some(deps) = job_deps.get(glue_job) {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -251,6 +251,8 @@ pub struct Coordinator<'roc> {
 
     // caches
     path_to_hash: HashMap<PathBuf, String>,
+
+    // TODO: have more of a think about whether this mapping (from Base instead of Final) is safe
     job_to_content_hash: HashMap<job::Key<job::Base>, String>,
 
     // which jobs should run when?

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -310,7 +310,18 @@ impl<'roc> Coordinator<'roc> {
                     .with_context(|| format!("could not create workspace for {}", job))?;
 
                 workspace
-                    .set_up_files(job)
+                    .set_up_files(
+                        job,
+                        &self
+                            .job_to_content_hash
+                            .iter()
+                            // TODO: this is a massive, boundary-breaking hack
+                            // to just get something on the screen while I'm
+                            // developing. If you're looking at this in PR and
+                            // it's still here, make some noise!
+                            .map(|(k, hash)| (*k, self.workspace_root.join("store").join(hash)))
+                            .collect(),
+                    )
                     .with_context(|| format!("could not set up workspace files for {}", job))?;
 
                 runner.run(job, &workspace).context("could not run job")?;

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -307,8 +307,6 @@ impl<'roc> Coordinator<'roc> {
         {
             Some(item) => {
                 log::debug!("already had output of job {}; skipping", job);
-                // TODO: this clone smells like there's some responsibility in
-                // the wrong place. Can we get rid of it?
                 self.job_to_content_hash.insert(job.base_key, item);
             }
             None => {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -27,12 +27,12 @@ impl<'roc> Builder<'roc> {
             workspace_root,
             store,
 
-            // it's very likely we'll have at least one target
+            // it's very likely we'll have at least one root
             roots: Vec::with_capacity(1),
         }
     }
 
-    pub fn add_target(&mut self, job: &'roc glue::Job) {
+    pub fn add_root(&mut self, job: &'roc glue::Job) {
         self.roots.push(job);
     }
 

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -36,7 +36,7 @@ impl<'roc> Builder<'roc> {
         self.targets.push(job);
     }
 
-    pub fn build(mut self) -> Result<Coordinator<'roc>> {
+    pub fn build(self) -> Result<Coordinator<'roc>> {
         // Here's the overview of what we're about to do: for each file in
         // each target job, we're going to look at metadata for that file and
         // use that metadata to look up the file's hash (if we don't have it
@@ -170,13 +170,13 @@ impl<'roc> Builder<'roc> {
         ///////////////////////////////////////////////////////////////////////////
         // Phase 3: get the hahes to determine what jobs we actually need to run //
         ///////////////////////////////////////////////////////////////////////////
-        for glue_job in self.targets.drain(..) {
+        for glue_job in self.targets {
             // Note: this data structure is going to grow the ability to
             // refer to other jobs as soon as it's possibly feasible. When
             // that happens, a depth-first search through the tree rooted at
             // `glue_job` will probably suffice.
             let job =
-                Job::from_glue(&glue_job).context("could not convert glue job to actual job")?;
+                Job::from_glue(glue_job).context("could not convert glue job to actual job")?;
 
             // TODO: pushing to `ready` immediately is only reasonable when
             // we don't have job inputs as dependencies, but we don't have that

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -344,7 +344,7 @@ impl<'roc> Coordinator<'roc> {
         self.blocked.retain(|blocked, blockers| {
             let removed = blockers.remove(&id);
             if !removed {
-                return false;
+                return true;
             }
 
             let no_blockers_remaining = blockers.is_empty();

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -6,6 +6,8 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
+#![allow(unused_variables)]
+#![allow(clippy::unit_cmp)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(clippy::unused_unit)]

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -23,10 +23,28 @@
     target_arch = "x86",
     target_arch = "x86_64"
 ))]
-#[repr(transparent)]
-#[derive(Clone, Default, Eq, Ord, Hash, PartialEq, PartialOrd)]
-pub struct Input {
-    f0: roc_std::RocList<roc_std::RocStr>,
+#[derive(Clone, Copy, Eq, Ord, Hash, PartialEq, PartialOrd)]
+#[repr(u8)]
+pub enum discriminant_U1 {
+    FromJob = 0,
+    FromProjectSource = 1,
+}
+
+impl core::fmt::Debug for discriminant_U1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::FromJob => f.write_str("discriminant_U1::FromJob"),
+            Self::FromProjectSource => f.write_str("discriminant_U1::FromProjectSource"),
+        }
+    }
+}
+
+#[cfg(any(target_arch = "arm", target_arch = "wasm32", target_arch = "x86"))]
+#[repr(C)]
+pub union U1 {
+    FromJob: core::mem::ManuallyDrop<U1_FromJob>,
+    FromProjectSource: core::mem::ManuallyDrop<roc_std::RocList<roc_std::RocStr>>,
+    _sizer: [u8; 20],
 }
 
 #[cfg(any(
@@ -50,9 +68,33 @@ pub struct Rbt {
     target_arch = "x86_64"
 ))]
 #[repr(transparent)]
-#[derive(Clone, Eq, Ord, Hash, PartialEq, PartialOrd)]
 pub struct Job {
-    f0: R1,
+    pointer: *mut union_Job,
+}
+
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "wasm32",
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
+#[repr(C)]
+union union_Job {
+    Job: core::mem::ManuallyDrop<Job_Job>,
+}
+
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "wasm32",
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
+#[derive(Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
+#[repr(transparent)]
+struct Job_Job {
+    pub f0: R1,
 }
 
 #[cfg(any(
@@ -67,8 +109,22 @@ pub struct Job {
 pub struct R1 {
     pub command: Command,
     pub env: roc_std::RocDict<roc_std::RocStr, roc_std::RocStr>,
-    pub inputs: roc_std::RocList<Input>,
+    pub inputs: roc_std::RocList<U1>,
     pub outputs: roc_std::RocList<roc_std::RocStr>,
+}
+
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "wasm32",
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
+#[derive(Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
+#[repr(C)]
+struct U1_FromJob {
+    pub f0: Job,
+    pub f1: roc_std::RocList<roc_std::RocStr>,
 }
 
 #[cfg(any(
@@ -111,17 +167,33 @@ pub struct SystemToolPayload {
     pub name: roc_std::RocStr,
 }
 
-impl Input {
-    #[cfg(any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "wasm32",
-        target_arch = "x86",
-        target_arch = "x86_64"
-    ))]
-    /// A tag named FromProjectSource, with the given payload.
-    pub fn FromProjectSource(f0: roc_std::RocList<roc_std::RocStr>) -> Self {
-        Self { f0 }
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[repr(C)]
+pub union U1 {
+    FromJob: core::mem::ManuallyDrop<U1_FromJob>,
+    FromProjectSource: core::mem::ManuallyDrop<roc_std::RocList<roc_std::RocStr>>,
+    _sizer: [u8; 40],
+}
+
+impl U1 {
+    #[cfg(any(target_arch = "arm", target_arch = "wasm32", target_arch = "x86"))]
+    /// Returns which variant this tag union holds. Note that this never includes a payload!
+    pub fn discriminant(&self) -> discriminant_U1 {
+        unsafe {
+            let bytes = core::mem::transmute::<&Self, &[u8; core::mem::size_of::<Self>()]>(self);
+
+            core::mem::transmute::<u8, discriminant_U1>(*bytes.as_ptr().add(16))
+        }
+    }
+
+    #[cfg(any(target_arch = "arm", target_arch = "wasm32", target_arch = "x86"))]
+    /// Internal helper
+    fn set_discriminant(&mut self, discriminant: discriminant_U1) {
+        let discriminant_ptr: *mut discriminant_U1 = (self as *mut U1).cast();
+
+        unsafe {
+            *(discriminant_ptr.add(16)) = discriminant;
+        }
     }
 
     #[cfg(any(
@@ -131,10 +203,15 @@ impl Input {
         target_arch = "x86",
         target_arch = "x86_64"
     ))]
-    /// Since `FromProjectSource` only has one tag (namely, `FromProjectSource`),
-    /// convert it to `FromProjectSource`'s payload.
-    pub fn into_FromProjectSource(self) -> roc_std::RocList<roc_std::RocStr> {
-        self.f0
+    /// Construct a tag named `FromJob`, with the appropriate payload
+    pub fn FromJob(arg0: Job, arg1: roc_std::RocList<roc_std::RocStr>) -> Self {
+        let mut answer = Self {
+            FromJob: core::mem::ManuallyDrop::new(U1_FromJob { f0: arg0, f1: arg1 }),
+        };
+
+        answer.set_discriminant(discriminant_U1::FromJob);
+
+        answer
     }
 
     #[cfg(any(
@@ -144,14 +221,274 @@ impl Input {
         target_arch = "x86",
         target_arch = "x86_64"
     ))]
-    /// Since `FromProjectSource` only has one tag (namely, `FromProjectSource`),
-    /// convert it to `FromProjectSource`'s payload.
-    pub fn as_FromProjectSource(&self) -> &roc_std::RocList<roc_std::RocStr> {
-        &self.f0
+    /// Unsafely assume the given `U1` has a `.discriminant()` of `FromJob` and convert it to `FromJob`'s payload.
+    /// (Always examine `.discriminant()` first to make sure this is the correct variant!)
+    /// Panics in debug builds if the `.discriminant()` doesn't return `FromJob`.
+    pub unsafe fn into_FromJob(mut self) -> (Job, roc_std::RocList<roc_std::RocStr>) {
+        debug_assert_eq!(self.discriminant(), discriminant_U1::FromJob);
+        let payload = {
+            let mut uninitialized = core::mem::MaybeUninit::uninit();
+            let swapped = unsafe {
+                core::mem::replace(
+                    &mut self.FromJob,
+                    core::mem::ManuallyDrop::new(uninitialized.assume_init()),
+                )
+            };
+
+            core::mem::forget(self);
+
+            core::mem::ManuallyDrop::into_inner(swapped)
+        };
+
+        (payload.f0, payload.f1)
+    }
+
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    /// Unsafely assume the given `U1` has a `.discriminant()` of `FromJob` and return its payload.
+    /// (Always examine `.discriminant()` first to make sure this is the correct variant!)
+    /// Panics in debug builds if the `.discriminant()` doesn't return `FromJob`.
+    pub unsafe fn as_FromJob(&self) -> (&Job, &roc_std::RocList<roc_std::RocStr>) {
+        debug_assert_eq!(self.discriminant(), discriminant_U1::FromJob);
+        let payload = &self.FromJob;
+
+        (&payload.f0, &payload.f1)
+    }
+
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    /// Construct a tag named `FromProjectSource`, with the appropriate payload
+    pub fn FromProjectSource(arg: roc_std::RocList<roc_std::RocStr>) -> Self {
+        let mut answer = Self {
+            FromProjectSource: core::mem::ManuallyDrop::new(arg),
+        };
+
+        answer.set_discriminant(discriminant_U1::FromProjectSource);
+
+        answer
+    }
+
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    /// Unsafely assume the given `U1` has a `.discriminant()` of `FromProjectSource` and convert it to `FromProjectSource`'s payload.
+    /// (Always examine `.discriminant()` first to make sure this is the correct variant!)
+    /// Panics in debug builds if the `.discriminant()` doesn't return `FromProjectSource`.
+    pub unsafe fn into_FromProjectSource(mut self) -> roc_std::RocList<roc_std::RocStr> {
+        debug_assert_eq!(self.discriminant(), discriminant_U1::FromProjectSource);
+        let payload = {
+            let mut uninitialized = core::mem::MaybeUninit::uninit();
+            let swapped = unsafe {
+                core::mem::replace(
+                    &mut self.FromProjectSource,
+                    core::mem::ManuallyDrop::new(uninitialized.assume_init()),
+                )
+            };
+
+            core::mem::forget(self);
+
+            core::mem::ManuallyDrop::into_inner(swapped)
+        };
+
+        payload
+    }
+
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    /// Unsafely assume the given `U1` has a `.discriminant()` of `FromProjectSource` and return its payload.
+    /// (Always examine `.discriminant()` first to make sure this is the correct variant!)
+    /// Panics in debug builds if the `.discriminant()` doesn't return `FromProjectSource`.
+    pub unsafe fn as_FromProjectSource(&self) -> &roc_std::RocList<roc_std::RocStr> {
+        debug_assert_eq!(self.discriminant(), discriminant_U1::FromProjectSource);
+        let payload = &self.FromProjectSource;
+
+        &payload
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    /// Returns which variant this tag union holds. Note that this never includes a payload!
+    pub fn discriminant(&self) -> discriminant_U1 {
+        unsafe {
+            let bytes = core::mem::transmute::<&Self, &[u8; core::mem::size_of::<Self>()]>(self);
+
+            core::mem::transmute::<u8, discriminant_U1>(*bytes.as_ptr().add(32))
+        }
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    /// Internal helper
+    fn set_discriminant(&mut self, discriminant: discriminant_U1) {
+        let discriminant_ptr: *mut discriminant_U1 = (self as *mut U1).cast();
+
+        unsafe {
+            *(discriminant_ptr.add(32)) = discriminant;
+        }
     }
 }
 
-impl core::fmt::Debug for Input {
+impl Drop for U1 {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn drop(&mut self) {
+        // Drop the payloads
+        match self.discriminant() {
+            discriminant_U1::FromJob => unsafe { core::mem::ManuallyDrop::drop(&mut self.FromJob) },
+            discriminant_U1::FromProjectSource => unsafe {
+                core::mem::ManuallyDrop::drop(&mut self.FromProjectSource)
+            },
+        }
+    }
+}
+
+impl Eq for U1 {}
+
+impl PartialEq for U1 {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn eq(&self, other: &Self) -> bool {
+        if self.discriminant() != other.discriminant() {
+            return false;
+        }
+
+        unsafe {
+            match self.discriminant() {
+                discriminant_U1::FromJob => self.FromJob == other.FromJob,
+                discriminant_U1::FromProjectSource => {
+                    self.FromProjectSource == other.FromProjectSource
+                }
+            }
+        }
+    }
+}
+
+impl PartialOrd for U1 {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        match self.discriminant().partial_cmp(&other.discriminant()) {
+            Some(core::cmp::Ordering::Equal) => {}
+            not_eq => return not_eq,
+        }
+
+        unsafe {
+            match self.discriminant() {
+                discriminant_U1::FromJob => self.FromJob.partial_cmp(&other.FromJob),
+                discriminant_U1::FromProjectSource => {
+                    self.FromProjectSource.partial_cmp(&other.FromProjectSource)
+                }
+            }
+        }
+    }
+}
+
+impl Ord for U1 {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        match self.discriminant().cmp(&other.discriminant()) {
+            core::cmp::Ordering::Equal => {}
+            not_eq => return not_eq,
+        }
+
+        unsafe {
+            match self.discriminant() {
+                discriminant_U1::FromJob => self.FromJob.cmp(&other.FromJob),
+                discriminant_U1::FromProjectSource => {
+                    self.FromProjectSource.cmp(&other.FromProjectSource)
+                }
+            }
+        }
+    }
+}
+
+impl Clone for U1 {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn clone(&self) -> Self {
+        let mut answer = unsafe {
+            match self.discriminant() {
+                discriminant_U1::FromJob => Self {
+                    FromJob: self.FromJob.clone(),
+                },
+                discriminant_U1::FromProjectSource => Self {
+                    FromProjectSource: self.FromProjectSource.clone(),
+                },
+            }
+        };
+
+        answer.set_discriminant(self.discriminant());
+
+        answer
+    }
+}
+
+impl core::hash::Hash for U1 {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        match self.discriminant() {
+            discriminant_U1::FromJob => unsafe {
+                discriminant_U1::FromJob.hash(state);
+                self.FromJob.hash(state);
+            },
+            discriminant_U1::FromProjectSource => unsafe {
+                discriminant_U1::FromProjectSource.hash(state);
+                self.FromProjectSource.hash(state);
+            },
+        }
+    }
+}
+
+impl core::fmt::Debug for U1 {
     #[cfg(any(
         target_arch = "arm",
         target_arch = "aarch64",
@@ -160,9 +497,21 @@ impl core::fmt::Debug for Input {
         target_arch = "x86_64"
     ))]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Input::FromProjectSource")
-            .field(&self.f0)
-            .finish()
+        f.write_str("U1::")?;
+
+        unsafe {
+            match self.discriminant() {
+                discriminant_U1::FromJob => f
+                    .debug_tuple("FromJob")
+                    .field(&(&*self.FromJob).f0)
+                    .field(&(&*self.FromJob).f1)
+                    .finish(),
+                discriminant_U1::FromProjectSource => f
+                    .debug_tuple("FromProjectSource")
+                    .field(&*self.FromProjectSource)
+                    .finish(),
+            }
+        }
     }
 }
 
@@ -174,9 +523,10 @@ impl Job {
         target_arch = "x86",
         target_arch = "x86_64"
     ))]
-    /// A tag named Job, with the given payload.
-    pub fn Job(f0: R1) -> Self {
-        Self { f0 }
+    fn storage(&self) -> Option<&core::cell::Cell<roc_std::Storage>> {
+        let untagged = self.pointer as *const core::cell::Cell<roc_std::Storage>;
+
+        unsafe { Some(&*untagged.sub(1)) }
     }
 
     #[cfg(any(
@@ -186,23 +536,221 @@ impl Job {
         target_arch = "x86",
         target_arch = "x86_64"
     ))]
+    /// This is a single-tag union, so it has no alternatives
+    /// to discriminate between. This method is only included for completeness.
+    pub fn discriminant(&self) -> () {
+        ()
+    }
+
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    /// Construct a tag named `Job`, with the appropriate payload
+    pub fn Job(arg0: R1) -> Self {
+        let size = core::mem::size_of::<union_Job>();
+        let align = core::mem::align_of::<union_Job>() as u32;
+
+        unsafe {
+            let ptr = roc_std::roc_alloc_refcounted::<union_Job>();
+
+            *ptr = union_Job {
+                Job: core::mem::ManuallyDrop::new(Job_Job { f0: arg0 }),
+            };
+
+            Self { pointer: ptr }
+        }
+    }
+
+    #[cfg(any(target_arch = "arm", target_arch = "wasm32", target_arch = "x86"))]
     /// Since `Job` only has one tag (namely, `Job`),
     /// convert it to `Job`'s payload.
-    pub fn into_Job(self) -> R1 {
-        self.f0
+    pub fn into_Job(mut self) -> R1 {
+        let payload = {
+            let ptr = (self.pointer as usize & !0b11) as *mut union_Job;
+            let mut uninitialized = core::mem::MaybeUninit::uninit();
+            let swapped = unsafe {
+                core::mem::replace(
+                    &mut (*ptr).Job,
+                    core::mem::ManuallyDrop::new(uninitialized.assume_init()),
+                )
+            };
+
+            core::mem::forget(self);
+
+            core::mem::ManuallyDrop::into_inner(swapped)
+        };
+
+        payload.f0
     }
 
-    #[cfg(any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "wasm32",
-        target_arch = "x86",
-        target_arch = "x86_64"
-    ))]
+    #[cfg(any(target_arch = "arm", target_arch = "wasm32", target_arch = "x86"))]
     /// Since `Job` only has one tag (namely, `Job`),
     /// convert it to `Job`'s payload.
     pub fn as_Job(&self) -> &R1 {
-        &self.f0
+        let payload = {
+            let ptr = (self.pointer as usize & !0b11) as *mut union_Job;
+
+            unsafe { &(*ptr).Job }
+        };
+
+        &payload.f0
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    /// Since `Job` only has one tag (namely, `Job`),
+    /// convert it to `Job`'s payload.
+    pub fn into_Job(mut self) -> R1 {
+        let payload = {
+            let ptr = (self.pointer as usize & !0b111) as *mut union_Job;
+            let mut uninitialized = core::mem::MaybeUninit::uninit();
+            let swapped = unsafe {
+                core::mem::replace(
+                    &mut (*ptr).Job,
+                    core::mem::ManuallyDrop::new(uninitialized.assume_init()),
+                )
+            };
+
+            core::mem::forget(self);
+
+            core::mem::ManuallyDrop::into_inner(swapped)
+        };
+
+        payload.f0
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    /// Since `Job` only has one tag (namely, `Job`),
+    /// convert it to `Job`'s payload.
+    pub fn as_Job(&self) -> &R1 {
+        let payload = {
+            let ptr = (self.pointer as usize & !0b111) as *mut union_Job;
+
+            unsafe { &(*ptr).Job }
+        };
+
+        &payload.f0
+    }
+}
+
+impl Drop for Job {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn drop(&mut self) {
+        // We only need to do any work if there's actually a heap-allocated payload.
+        if let Some(storage) = self.storage() {
+            let mut new_storage = storage.get();
+
+            // Decrement the refcount
+            let needs_dealloc = !new_storage.is_readonly() && new_storage.decrease();
+
+            if needs_dealloc {
+                // Drop the payload first.
+                unsafe {
+                    core::mem::ManuallyDrop::drop(&mut core::ptr::read(self.pointer).Job);
+                }
+
+                // Dealloc the pointer
+                let alignment =
+                    core::mem::align_of::<Self>().max(core::mem::align_of::<roc_std::Storage>());
+
+                unsafe {
+                    crate::roc_dealloc(storage.as_ptr().cast(), alignment as u32);
+                }
+            } else {
+                // Write the storage back.
+                storage.set(new_storage);
+            }
+        }
+    }
+}
+
+impl Eq for Job {}
+
+impl PartialEq for Job {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn eq(&self, other: &Self) -> bool {
+        if self.discriminant() != other.discriminant() {
+            return false;
+        }
+
+        unsafe { (*self.pointer).Job == (*other.pointer).Job }
+    }
+}
+
+impl PartialOrd for Job {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        unsafe { (&*self.pointer).Job.partial_cmp(&(*other.pointer).Job) }
+    }
+}
+
+impl Ord for Job {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        unsafe { (&*self.pointer).Job.cmp(&(*other.pointer).Job) }
+    }
+}
+
+impl Clone for Job {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn clone(&self) -> Self {
+        if let Some(storage) = self.storage() {
+            let mut new_storage = storage.get();
+            if !new_storage.is_readonly() {
+                new_storage.increment_reference_count();
+                storage.set(new_storage);
+            }
+        }
+
+        Self {
+            pointer: self.pointer,
+        }
+    }
+}
+
+impl core::hash::Hash for Job {
+    #[cfg(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "wasm32",
+        target_arch = "x86",
+        target_arch = "x86_64"
+    ))]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        unsafe { (*self.pointer).Job.hash(state) }
     }
 }
 
@@ -215,7 +763,9 @@ impl core::fmt::Debug for Job {
         target_arch = "x86_64"
     ))]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Job::Job").field(&self.f0).finish()
+        f.write_str("Job::")?;
+
+        unsafe { f.debug_tuple("Job").field(&(*self.pointer).Job).finish() }
     }
 }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -35,6 +35,10 @@ impl KeyBuilder {
         content_hash.hash(&mut self.0);
     }
 
+    pub fn add_dependency(&mut self, dep: &str) {
+        dep.hash(&mut self.0);
+    }
+
     pub fn finalize(self) -> Key<Final> {
         Key {
             key: self.0.finish(),
@@ -44,11 +48,11 @@ impl KeyBuilder {
 }
 
 /// See docs on `Key`
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
 pub struct Base;
 
 /// See docs on `Key`
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
 pub struct Final;
 
 /// A cache key for a job. This has a phantom type parameter because we calculate
@@ -56,7 +60,9 @@ pub struct Final;
 /// the information passed in from a `glue::Job`. The second includes information
 /// we'd have to do I/O for (like file hashes.) For more on the architecture,
 /// see `docs/internals/how-we-determine-when-to-run-jobs.md`.
-#[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Eq, Hash, PartialEq, Clone, PartialOrd, Ord, Copy, serde::Serialize, serde::Deserialize,
+)]
 #[serde(transparent)]
 pub struct Key<Finality> {
     key: u64,

--- a/src/job.rs
+++ b/src/job.rs
@@ -91,12 +91,17 @@ impl Job {
 
         let mut input_files: HashSet<PathBuf> = HashSet::with_capacity(unwrapped.inputs.len());
         for input in unwrapped.inputs.iter().sorted() {
-            for file in input.as_FromProjectSource().iter().sorted() {
-                let path =
-                    sanitize_file_path(file).context("got an unacceptable input file path")?;
+            match input.discriminant() {
+                glue::discriminant_U1::FromJob => todo!(),
+                glue::discriminant_U1::FromProjectSource => {
+                    for file in unsafe { input.as_FromProjectSource() }.iter().sorted() {
+                        let path = sanitize_file_path(file)
+                            .context("got an unacceptable input file path")?;
 
-                path.hash(&mut hasher);
-                input_files.insert(path);
+                        path.hash(&mut hasher);
+                        input_files.insert(path);
+                    }
+                }
             }
         }
 
@@ -231,7 +236,7 @@ mod test {
                 args: RocList::from_slice(&["-c".into(), "Hello, World".into()]),
             },
             env: RocDict::with_capacity(0),
-            inputs: RocList::from_slice(&[glue::Input::FromProjectSource(RocList::from([
+            inputs: RocList::from_slice(&[glue::U1::FromProjectSource(RocList::from([
                 "input_file".into(),
             ]))]),
             outputs: RocList::from_slice(&["output_file".into()]),

--- a/src/job.rs
+++ b/src/job.rs
@@ -164,7 +164,7 @@ impl<'roc> Job<'roc> {
         for path in &self.input_files {
             match path_to_hash.get(path) {
                 Some(hash) => {
-                    path.hash(&mut hasher);
+                    // we don't need to hash the path, as we already have it in the base key
                     hash.hash(&mut hasher);
                 },
                 None => anyhow::bail!("`{}` was specified as a file dependency, but I didn't have a hash for it! This is a bug in rbt's coordinator, please file it!", path.display()),

--- a/src/job.rs
+++ b/src/job.rs
@@ -35,7 +35,7 @@ impl KeyBuilder {
         content_hash.hash(&mut self.0);
     }
 
-    pub fn add_dependency(&mut self, dep: &str) {
+    pub fn add_dependency(&mut self, dep: &blake3::Hash) {
         dep.hash(&mut self.0);
     }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -91,17 +91,18 @@ impl Job {
 
         let mut input_files: HashSet<PathBuf> = HashSet::with_capacity(unwrapped.inputs.len());
         for input in unwrapped.inputs.iter().sorted() {
-            match input.discriminant() {
-                glue::discriminant_U1::FromJob => todo!(),
-                glue::discriminant_U1::FromProjectSource => {
-                    for file in unsafe { input.as_FromProjectSource() }.iter().sorted() {
-                        let path = sanitize_file_path(file)
-                            .context("got an unacceptable input file path")?;
+            // TODO: we don't need job inputs yet, but we will need their
+            // destination paths when `FileMapping` is implemented (see ADR 008)
+            if input.discriminant() != glue::discriminant_U1::FromProjectSource {
+                continue;
+            }
 
-                        path.hash(&mut hasher);
-                        input_files.insert(path);
-                    }
-                }
+            for file in unsafe { input.as_FromProjectSource() }.iter().sorted() {
+                let path =
+                    sanitize_file_path(file).context("got an unacceptable input file path")?;
+
+                path.hash(&mut hasher);
+                input_files.insert(path);
             }
         }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -117,6 +117,9 @@ impl<'roc> Job<'roc> {
                         let path = sanitize_file_path(file)
                             .context("got an unnacceptable input file path")?;
 
+                        // TODO: when we have mapped filenames, both components
+                        // of the mapped file name should be added to the hash
+                        // here. (See ADR 008)
                         path.hash(&mut hasher);
                         job_files.insert(path);
                     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -43,14 +43,11 @@ impl Store {
         })
     }
 
-    pub fn hash_for_job(&self, key: &job::Key<job::Final>) -> Option<&String> {
-        self.inputs_to_content.get(key)
-    }
-
-    /// If an output exists for a job, what is it? If we don't have a stored
-    /// output for the job, return `None`.
-    pub fn path_for_job(&self, key: &job::Key<job::Final>) -> Option<PathBuf> {
-        self.hash_for_job(key).map(|path| self.root.join(path))
+    pub fn item_for_job(&self, key: &job::Key<job::Final>) -> Result<Option<Item>> {
+        match self.inputs_to_content.get(key) {
+            None => Ok(None),
+            Some(hash) => Item::from_hex(&self.root, hash).map(Some),
+        }
     }
 
     /// Figure out if we need to make a new content-addressable item from the
@@ -72,25 +69,18 @@ impl Store {
         key: job::Key<job::Final>,
         job: &Job,
         workspace: Workspace,
-    ) -> Result<String> {
-        let item = ItemBuilder::load(job, workspace)
+    ) -> Result<Item> {
+        let item_builder = ItemBuilder::load(&self.root, job, workspace)
             .context("could get content addressed path from job")?;
 
-        if item.exists_in(&self.root) {
-            log::debug!("we have already stored {}, so I'm skipping the move!", item,);
+        let item = item_builder
+            .move_into_checked(&self.root)
+            .context("could not move item into the store")?;
 
-            self.associate_job_with_hash(key, &item.hash().to_string())
-                .context("could not associate job with hash")
-        } else {
-            log::debug!("moving {} into store", item);
+        self.associate_job_with_hash(key, &item.to_string())
+            .context("could not associate job with hash")?;
 
-            let hash = item
-                .move_into(&self.root)
-                .context("could not move item into the store")?;
-
-            self.associate_job_with_hash(key, &hash.to_string())
-                .context("could not associate job with hash")
-        }
+        Ok(item)
     }
 
     fn associate_job_with_hash(&mut self, key: job::Key<job::Final>, hash: &str) -> Result<String> {
@@ -112,13 +102,13 @@ impl Store {
 struct ItemBuilder<'job> {
     workspace: Workspace,
     job: &'job Job<'job>,
-    hash: blake3::Hash,
+    item: Item,
 }
 
 impl<'job> ItemBuilder<'job> {
     /// Load all the outputs from a job and workspace combo, creating a hash
     /// as we go.
-    fn load(job: &'job Job, workspace: Workspace) -> Result<Self> {
+    fn load(root: &Path, job: &'job Job, workspace: Workspace) -> Result<Self> {
         let mut hasher = blake3::Hasher::new();
 
         for path in job.outputs.iter().sorted() {
@@ -146,29 +136,30 @@ impl<'job> ItemBuilder<'job> {
         Ok(Self {
             workspace,
             job,
-            hash: hasher.finalize(),
+            item: Item::from_hash(root, hasher.finalize()),
         })
     }
 
-    fn hash(&self) -> &blake3::Hash {
-        &self.hash
-    }
+    // like `move_into`, but checks that the store path exists first
+    fn move_into_checked(self, root: &Path) -> Result<Item> {
+        if self.item.exists() {
+            log::debug!("we have already stored {}, so I'm skipping the move!", self,);
 
-    fn final_path(&self, root: &Path) -> PathBuf {
-        root.join(self.to_string())
-    }
+            Ok(self.item)
+        } else {
+            log::debug!("moving {} into store", self);
 
-    /// Does this item exist as a path within the specified root?
-    fn exists_in(&self, root: &Path) -> bool {
-        self.final_path(root).exists()
+            self.move_into(root)
+                .context("could not move item into the store")
+        }
     }
 
     /// Move this item into the store. This consumes the item, since it won't be
     /// safe to do this twice (we move files from the owned `Workspace` / passed
     /// in with `load`) Returns the only safe thing to use after calling this:
     /// the hash.
-    fn move_into(self, root: &Path) -> Result<blake3::Hash> {
-        let final_path = self.final_path(root);
+    fn move_into(self, root: &Path) -> Result<Item> {
+        let final_path = self.item.path();
 
         let temp = tempfile::Builder::new()
             .prefix(&format!("tmp-{}", self))
@@ -261,7 +252,7 @@ impl<'job> ItemBuilder<'job> {
             .context("could not move temporary collection directory into the store")?;
         Self::make_readonly(&final_path).context("could not make store path readonly")?;
 
-        Ok(self.hash)
+        Ok(self.item)
     }
 
     fn make_readonly(path: &Path) -> Result<()> {
@@ -277,6 +268,50 @@ impl<'job> ItemBuilder<'job> {
 
 impl<'job> Display for ItemBuilder<'job> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.item.fmt(f)
+    }
+}
+
+#[derive(Debug)]
+pub struct Item {
+    hash: blake3::Hash,
+    path: PathBuf,
+}
+
+impl Item {
+    fn from_hash(root: &Path, hash: blake3::Hash) -> Self {
+        Item {
+            hash,
+            path: root.join(hash.to_hex().to_string()),
+        }
+    }
+
+    fn from_hex(root: &Path, hex: &str) -> Result<Self> {
+        let hash = blake3::Hash::from_hex(hex)
+            .with_context(|| format!("could not load a blake3 hash from hex value `{}`", hex))?;
+
+        Ok(Self::from_hash(root, hash))
+    }
+
+    pub fn hash(&self) -> blake3::Hash {
+        self.hash
+    }
+
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+
+impl Display for Item {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.hash.fmt(f)
+    }
+}
+
+impl std::ops::Deref for Item {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -107,7 +107,7 @@ impl Store {
 #[derive(Debug)]
 struct ContentAddressedItem<'job> {
     workspace: Workspace,
-    job: &'job Job,
+    job: &'job Job<'job>,
     hash: blake3::Hash,
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -73,8 +73,8 @@ impl Store {
         job: &Job,
         workspace: Workspace,
     ) -> Result<String> {
-        let item = ContentAddressedItem::load(job, workspace)
-            .context("could get content addressable item from job")?;
+        let item = ItemBuilder::load(job, workspace)
+            .context("could get content addressed path from job")?;
 
         if item.exists_in(&self.root) {
             log::debug!("we have already stored {}, so I'm skipping the move!", item,);
@@ -109,13 +109,13 @@ impl Store {
 /// ContentAddressedItem is responsible for hashing the outputs of a job inside
 /// a workspace and (maybe) moving those outputs into the store.
 #[derive(Debug)]
-struct ContentAddressedItem<'job> {
+struct ItemBuilder<'job> {
     workspace: Workspace,
     job: &'job Job<'job>,
     hash: blake3::Hash,
 }
 
-impl<'job> ContentAddressedItem<'job> {
+impl<'job> ItemBuilder<'job> {
     /// Load all the outputs from a job and workspace combo, creating a hash
     /// as we go.
     fn load(job: &'job Job, workspace: Workspace) -> Result<Self> {
@@ -275,7 +275,7 @@ impl<'job> ContentAddressedItem<'job> {
     }
 }
 
-impl<'job> Display for ContentAddressedItem<'job> {
+impl<'job> Display for ItemBuilder<'job> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.hash.fmt(f)
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -250,7 +250,7 @@ impl<'job> ItemBuilder<'job> {
         // around in case of errors.
         std::fs::rename(temp.into_path(), &final_path)
             .context("could not move temporary collection directory into the store")?;
-        Self::make_readonly(&final_path).context("could not make store path readonly")?;
+        Self::make_readonly(final_path).context("could not make store path readonly")?;
 
         Ok(self.item)
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -196,7 +196,7 @@ impl<'job> ContentAddressedItem<'job> {
             let mut ancestors: Vec<&Path> = output.ancestors().skip(1).collect();
             ancestors.pop(); // removing the full path at the end of the list
 
-            // // the collection is now ordered `[a/b/c, a/b, a]` instead of
+            // the collection is now ordered `[a/b/c, a/b, a]` instead of
             // `[a, a/b, a/b/c]`, but we need it to be shortest-path-first to
             // successfully create the directories in order. Reverse!
             ancestors.reverse();

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -110,7 +110,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn key() -> job::Key<job::Final> {
-        job::KeyBuilder::mock().finalize()
+        job::Key::default()
     }
 
     fn glue_job_with_files<'roc>(files: &[&str]) -> glue::Job {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,4 +1,4 @@
-use crate::job;
+use crate::{job, store};
 use anyhow::{Context, Result};
 use path_absolutize::Absolutize;
 use std::collections::HashMap;
@@ -26,19 +26,19 @@ impl Workspace {
     pub fn set_up_files(
         &self,
         job: &job::Job,
-        job_to_store_path: &HashMap<job::Key<job::Base>, PathBuf>,
+        job_to_store_path: &HashMap<job::Key<job::Base>, store::Item>,
     ) -> Result<()> {
         for file in &job.input_files {
             self.set_up_path(file, file)?
         }
 
         for (key, files) in &job.input_jobs {
-            let store_path = job_to_store_path
+            let store_item = job_to_store_path
                 .get(key)
                 .with_context(|| format!("could not find a store path for job {}", key))?;
 
             for file in files {
-                self.set_up_path(&store_path.join(file), file)?
+                self.set_up_path(&store_item.join(file), file)?
             }
         }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -88,7 +88,7 @@ mod tests {
     use super::*;
     use crate::glue;
     use roc_std::{RocDict, RocList, RocStr};
-    use std::path::PathBuf;
+    use std::{collections::HashMap, path::PathBuf};
     use tempfile::TempDir;
 
     fn key() -> job::Key<job::Final> {
@@ -134,7 +134,7 @@ mod tests {
         let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
 
         let glue_job = glue_job_with_files(&[file!()]);
-        let job = job::Job::from_glue(&glue_job).unwrap();
+        let job = job::Job::from_glue(&glue_job, &HashMap::new()).unwrap();
         workspace
             .set_up_files(&job)
             .expect("failed to set up files");
@@ -154,7 +154,7 @@ mod tests {
 
         let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
         let glue_job = glue_job_with_files(&["does-not-exist"]);
-        let job = job::Job::from_glue(&glue_job).unwrap();
+        let job = job::Job::from_glue(&glue_job, &HashMap::new()).unwrap();
 
         assert_eq!(
             String::from("`does-not-exist` does not exist"),
@@ -173,7 +173,7 @@ mod tests {
         let parent = here.parent().unwrap();
 
         let glue_job = glue_job_with_files(&[parent.to_str().unwrap()]);
-        let job = job::Job::from_glue(&glue_job).unwrap();
+        let job = job::Job::from_glue(&glue_job, &HashMap::new()).unwrap();
 
         assert_eq!(
             format!(

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -95,8 +95,8 @@ mod tests {
         job::KeyBuilder::mock().finalize()
     }
 
-    fn job_with_files(files: &[&str]) -> job::Job {
-        let glue_job = glue::Job::Job(glue::R1 {
+    fn glue_job_with_files<'roc>(files: &[&str]) -> glue::Job {
+        glue::Job::Job(glue::R1 {
             command: glue::Command {
                 tool: glue::Tool::SystemTool(glue::SystemToolPayload {
                     name: RocStr::from("bash"),
@@ -111,9 +111,7 @@ mod tests {
             )]),
             outputs: RocList::empty(),
             env: RocDict::with_capacity(0),
-        });
-
-        job::Job::from_glue(glue_job).unwrap()
+        })
     }
 
     #[test]
@@ -135,7 +133,8 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
 
-        let job = job_with_files(&[file!()]);
+        let glue_job = glue_job_with_files(&[file!()]);
+        let job = job::Job::from_glue(&glue_job).unwrap();
         workspace
             .set_up_files(&job)
             .expect("failed to set up files");
@@ -154,7 +153,8 @@ mod tests {
         let temp = TempDir::new().unwrap();
 
         let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
-        let job = job_with_files(&["does-not-exist"]);
+        let glue_job = glue_job_with_files(&["does-not-exist"]);
+        let job = job::Job::from_glue(&glue_job).unwrap();
 
         assert_eq!(
             String::from("`does-not-exist` does not exist"),
@@ -172,7 +172,8 @@ mod tests {
         let here = PathBuf::from(file!());
         let parent = here.parent().unwrap();
 
-        let job = job_with_files(&[parent.to_str().unwrap()]);
+        let glue_job = glue_job_with_files(&[parent.to_str().unwrap()]);
+        let job = job::Job::from_glue(&glue_job).unwrap();
 
         assert_eq!(
             format!(

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -103,7 +103,7 @@ mod tests {
                 }),
                 args: RocList::empty(),
             },
-            inputs: RocList::from_slice(&[glue::Input::FromProjectSource(
+            inputs: RocList::from_slice(&[glue::U1::FromProjectSource(
                 files
                     .iter()
                     .map(|name| (*name).into())

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,6 +1,7 @@
 use crate::job;
 use anyhow::{Context, Result};
 use path_absolutize::Absolutize;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -22,44 +23,61 @@ impl Workspace {
         Ok(workspace)
     }
 
-    pub fn set_up_files(&self, job: &job::Job) -> Result<()> {
+    pub fn set_up_files(
+        &self,
+        job: &job::Job,
+        job_to_store_path: &HashMap<job::Key<job::Base>, PathBuf>,
+    ) -> Result<()> {
         for file in &job.input_files {
-            if let Some(parent_base) = file.parent() {
-                let parent = self.join(parent_base);
-
-                if !parent.exists() {
-                    fs::create_dir_all(parent).with_context(|| {
-                        format!("could not create parent for `{}`", file.display())
-                    })?;
-                }
-            }
-
-            // validate that the path exists and is a file
-            let meta = file
-                .metadata()
-                .with_context(|| format!("`{}` does not exist", file.display()))?;
-
-            if meta.is_dir() {
-                anyhow::bail!(
-                    "`{}` was a directory, but file inputs can only be files",
-                    file.display()
-                )
-            }
-
-            let source = file.absolutize().with_context(|| {
-                format!("could not convert `{}` to an absolute path", file.display())
-            })?;
-
-            #[cfg(target_family = "unix")]
-            symlink(source, self.join(file)).with_context(|| {
-                format!("could not symlink `{}` into workspace", file.display())
-            })?;
-
-            #[cfg(target_family = "windows")]
-            symlink_file(source, workspace.join(file)).with_context(|| {
-                format!("could not symlink `{}` into workspace", file.display())
-            })?;
+            self.set_up_path(file, file)?
         }
+
+        for (key, files) in &job.input_jobs {
+            let store_path = job_to_store_path
+                .get(key)
+                .with_context(|| format!("could not find a store path for job {}", key))?;
+
+            for file in files {
+                self.set_up_path(&store_path.join(file), file)?
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_up_path(&self, src: &Path, dest: &Path) -> Result<()> {
+        // validate that the path exists and is a file
+        let meta = src
+            .metadata()
+            .with_context(|| format!("`{}` does not exist", dest.display()))?;
+
+        if meta.is_dir() {
+            anyhow::bail!(
+                "`{}` was a directory, but workspace source paths can only be files",
+                src.display()
+            )
+        }
+
+        if let Some(parent_base) = dest.parent() {
+            let parent = self.join(parent_base);
+
+            if !parent.exists() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("could not create parent for `{}`", dest.display()))?;
+            }
+        }
+
+        let absolute_src = src.absolutize().with_context(|| {
+            format!("could not convert `{}` to an absolute path", src.display())
+        })?;
+
+        #[cfg(target_family = "unix")]
+        symlink(absolute_src, self.join(dest))
+            .with_context(|| format!("could not symlink `{}` into workspace", dest.display()))?;
+
+        #[cfg(target_family = "windows")]
+        symlink_file(absolute_src, workspace.join(dest))
+            .with_context(|| format!("could not symlink `{}` into workspace", file.display()))?;
 
         Ok(())
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -154,7 +154,7 @@ mod tests {
         let glue_job = glue_job_with_files(&[file!()]);
         let job = job::Job::from_glue(&glue_job, &HashMap::new()).unwrap();
         workspace
-            .set_up_files(&job)
+            .set_up_files(&job, &HashMap::new())
             .expect("failed to set up files");
 
         let path = workspace.join(file!());
@@ -176,7 +176,10 @@ mod tests {
 
         assert_eq!(
             String::from("`does-not-exist` does not exist"),
-            workspace.set_up_files(&job).unwrap_err().to_string(),
+            workspace
+                .set_up_files(&job, &HashMap::new())
+                .unwrap_err()
+                .to_string(),
         )
     }
 
@@ -195,10 +198,13 @@ mod tests {
 
         assert_eq!(
             format!(
-                "`{}` was a directory, but file inputs can only be files",
+                "`{}` was a directory, but workspace source paths can only be files",
                 parent.display()
             ),
-            workspace.set_up_files(&job).unwrap_err().to_string()
+            workspace
+                .set_up_files(&job, &HashMap::new())
+                .unwrap_err()
+                .to_string()
         );
     }
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -72,3 +72,18 @@ fn test_job_inputs() {
 
     assert_eq!(String::from("Hello, World!\n"), greeting)
 }
+
+#[test]
+fn test_job_inputs_branching() {
+    let root = TempDir::new().unwrap();
+
+    let store_path = output_of_default_job(
+        &root,
+        &PathBuf::from("tests/end_to_end/job_inputs_branching/rbt.roc"),
+    )
+    .unwrap();
+
+    let greeting = std::fs::read_to_string(store_path.join("out")).unwrap();
+
+    assert_eq!(String::from("Hello, World!\n"), greeting)
+}

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -1,37 +1,47 @@
-use assert_cmd::cmd::Command;
-use std::time::Duration;
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+fn output_of_default_job(root: &TempDir, rbt_dot_roc: &Path) -> Result<PathBuf> {
+    let current_dir = rbt_dot_roc
+        .parent()
+        .context("failed to get parent of the target rbt.roc")?;
+    let filename = rbt_dot_roc
+        .file_name()
+        .context("failed to get the filename of the target rbt.roc")?;
+
+    let output = std::process::Command::new("roc")
+        .arg("run")
+        .arg("--linker=legacy")
+        .arg(filename)
+        .arg("--")
+        .arg("--root-dir")
+        .arg(root.path().display().to_string())
+        .arg("--print-root-output-paths")
+        .current_dir(current_dir.display().to_string())
+        .output()
+        .context("failed to spawn `roc run`")?;
+
+    if !output.status.success() {
+        anyhow::bail!("failed to `roc run`: {:#?}", output);
+    }
+
+    Ok(PathBuf::from(
+        std::str::from_utf8(&output.stdout)
+            .context("could not convert output to a UTF-8 string")?
+            .trim(),
+    ))
+}
 
 #[test]
 fn test_file_inputs() {
     let root = TempDir::new().unwrap();
 
-    Command::new("roc")
-        .arg("run")
-        .arg("--linker=legacy")
-        .arg("rbt.roc")
-        .arg("--")
-        .arg("--root-dir")
-        .arg(root.path().display().to_string())
-        .current_dir("tests/end_to_end/file_inputs")
-        .timeout(Duration::from_secs(10))
-        .assert()
-        .success();
-
-    let store_path = root
-        .path()
-        .join("store")
-        .read_dir()
-        .expect("could not read dir")
-        .flatten()
-        .filter(|item| {
-            item.file_type()
-                .map(|ftype| ftype.is_dir())
-                .unwrap_or(false)
-        })
-        .map(|item| item.path())
-        .next()
-        .expect("expected at least one directory in the store path");
+    let store_path = output_of_default_job(
+        &root,
+        &PathBuf::from("tests/end_to_end/file_inputs/rbt.roc"),
+    )
+    .unwrap();
 
     let greeting = std::fs::read_to_string(store_path.join("out")).unwrap();
 
@@ -42,32 +52,8 @@ fn test_file_inputs() {
 fn test_env() {
     let root = TempDir::new().unwrap();
 
-    Command::new("roc")
-        .arg("run")
-        .arg("--linker=legacy")
-        .arg("rbt.roc")
-        .arg("--")
-        .arg("--root-dir")
-        .arg(root.path().display().to_string())
-        .current_dir("tests/end_to_end/env")
-        .timeout(Duration::from_secs(10))
-        .assert()
-        .success();
-
-    let store_path = root
-        .path()
-        .join("store")
-        .read_dir()
-        .expect("could not read dir")
-        .flatten()
-        .filter(|item| {
-            item.file_type()
-                .map(|ftype| ftype.is_dir())
-                .unwrap_or(false)
-        })
-        .map(|item| item.path())
-        .next()
-        .expect("expected at least one directory in the store path");
+    let store_path =
+        output_of_default_job(&root, &PathBuf::from("tests/end_to_end/env/rbt.roc")).unwrap();
 
     let greeting = std::fs::read_to_string(store_path.join("out")).unwrap();
 
@@ -78,32 +64,9 @@ fn test_env() {
 fn test_job_inputs() {
     let root = TempDir::new().unwrap();
 
-    Command::new("roc")
-        .arg("run")
-        .arg("--linker=legacy")
-        .arg("rbt.roc")
-        .arg("--")
-        .arg("--root-dir")
-        .arg(root.path().display().to_string())
-        .current_dir("tests/end_to_end/job_inputs")
-        .timeout(Duration::from_secs(10))
-        .assert()
-        .success();
-
-    let store_path = root
-        .path()
-        .join("store")
-        .read_dir()
-        .expect("could not read dir")
-        .flatten()
-        .filter(|item| {
-            item.file_type()
-                .map(|ftype| ftype.is_dir())
-                .unwrap_or(false)
-        })
-        .map(|item| item.path())
-        .next()
-        .expect("expected at least one directory in the store path");
+    let store_path =
+        output_of_default_job(&root, &PathBuf::from("tests/end_to_end/job_inputs/rbt.roc"))
+            .unwrap();
 
     let greeting = std::fs::read_to_string(store_path.join("out")).unwrap();
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -73,3 +73,39 @@ fn test_env() {
 
     assert_eq!(String::from("Hello, World!\n"), greeting)
 }
+
+#[test]
+fn test_job_inputs() {
+    let root = TempDir::new().unwrap();
+
+    Command::new("roc")
+        .arg("run")
+        .arg("--linker=legacy")
+        .arg("rbt.roc")
+        .arg("--")
+        .arg("--root-dir")
+        .arg(root.path().display().to_string())
+        .current_dir("tests/end_to_end/job_inputs")
+        .timeout(Duration::from_secs(10))
+        .assert()
+        .success();
+
+    let store_path = root
+        .path()
+        .join("store")
+        .read_dir()
+        .expect("could not read dir")
+        .flatten()
+        .filter(|item| {
+            item.file_type()
+                .map(|ftype| ftype.is_dir())
+                .unwrap_or(false)
+        })
+        .map(|item| item.path())
+        .next()
+        .expect("expected at least one directory in the store path");
+
+    let greeting = std::fs::read_to_string(store_path.join("out")).unwrap();
+
+    assert_eq!(String::from("Hello, World!\n"), greeting)
+}

--- a/tests/end_to_end/job_inputs/rbt.roc
+++ b/tests/end_to_end/job_inputs/rbt.roc
@@ -11,8 +11,14 @@ helloWorld : Job
 helloWorld =
     job {
         command: exec (systemTool "bash") [
+            "-euo",
+            "pipefail",
             "-c",
-            "printf '%s, %s!\n' \"$(cat greeting)\" \"$(cat subject)\" > out",
+            """
+            GREETING="$(cat greeting)"
+            SUBJECT="$(cat subject)"
+            printf '%s, %s!\n' "$GREETING" "$SUBJECT" > out
+            """
         ],
         inputs: [
             fromJob greeting [sourceFile "greeting"],

--- a/tests/end_to_end/job_inputs/rbt.roc
+++ b/tests/end_to_end/job_inputs/rbt.roc
@@ -1,0 +1,47 @@
+app "build"
+    packages { pf: "../../../Package-Config.roc" }
+    imports [pf.Rbt.{ Rbt, systemTool, Job, job, exec, projectFiles, sourceFile, fromJob }]
+    provides [init] to pf
+
+init : Rbt
+init =
+    Rbt.init { default: helloWorld }
+
+helloWorld : Job
+helloWorld =
+    job {
+        command: exec (systemTool "bash") [
+            "-c",
+            "printf '%s, %s!\n' \"$(cat greeting)\" \"$(cat subject)\" > out",
+        ],
+        inputs: [
+            fromJob greeting [sourceFile "greeting"],
+            fromJob subject [sourceFile "subject"],
+        ],
+        outputs: ["out"],
+        env: Dict.empty,
+    }
+
+greeting : Job
+greeting =
+    job {
+        command: exec (systemTool "bash") [
+            "-c",
+            "printf Hello > greeting",
+        ],
+        inputs: [],
+        outputs: ["greeting"],
+        env: Dict.empty,
+    }
+
+subject : Job
+subject =
+    job {
+        command: exec (systemTool "bash") [
+            "-c",
+            "printf World > subject",
+        ],
+        inputs: [],
+        outputs: ["subject"],
+        env: Dict.empty,
+    }

--- a/tests/end_to_end/job_inputs/rbt.roc
+++ b/tests/end_to_end/job_inputs/rbt.roc
@@ -18,7 +18,7 @@ helloWorld =
             GREETING="$(cat greeting)"
             SUBJECT="$(cat subject)"
             printf '%s, %s!\n' "$GREETING" "$SUBJECT" > out
-            """
+            """,
         ],
         inputs: [
             fromJob greeting [sourceFile "greeting"],

--- a/tests/end_to_end/job_inputs_branching/rbt.roc
+++ b/tests/end_to_end/job_inputs_branching/rbt.roc
@@ -1,0 +1,103 @@
+app "build"
+    packages { pf: "../../../Package-Config.roc" }
+    imports [pf.Rbt.{ Rbt, systemTool, Job, job, exec, projectFiles, sourceFile, fromJob }]
+    provides [init] to pf
+
+init : Rbt
+init =
+    Rbt.init { default: helloWorld }
+
+helloWorld : Job
+helloWorld =
+    job {
+        command: exec (systemTool "bash") [
+            "-euo",
+            "pipefail",
+            "-c",
+            """
+            GREETING="$(cat greeting)"
+            SUBJECT="$(cat subject)"
+            printf '%s, %s!\n' "$GREETING" "$SUBJECT" > out
+            """,
+        ],
+        inputs: [
+            fromJob greeting [sourceFile "greeting"],
+            fromJob subject [sourceFile "subject"],
+        ],
+        outputs: ["out"],
+        env: Dict.empty,
+    }
+
+greeting : Job
+greeting =
+    job {
+        command: exec (systemTool "bash") [
+            "-euo",
+            "pipefail",
+            "-c",
+            """
+            H=$(cat h)
+            E=$(cat e)
+            L=$(cat l)
+            O=$(cat o)
+            
+            printf '%s%s%s%s%s' $H $E $L $L $O > greeting
+            """,
+        ],
+        inputs: [
+            fromJob h [sourceFile "h"],
+            fromJob e [sourceFile "e"],
+            fromJob l [sourceFile "l"],
+            fromJob o [sourceFile "o"],
+        ],
+        outputs: ["greeting"],
+        env: Dict.empty,
+    }
+
+subject : Job
+subject =
+    job {
+        command: exec (systemTool "bash") [
+            "-euo",
+            "pipefail",
+            "-c",
+            """
+            W=$(cat w)
+            O=$(cat o)
+            R=$(cat r)
+            L=$(cat l)
+            D=$(cat d)
+            
+            printf '%s%s%s%s%s' $W $O $R $L $D > subject
+            """,
+        ],
+        inputs: [
+            fromJob w [sourceFile "w"],
+            fromJob o [sourceFile "o"],
+            fromJob r [sourceFile "r"],
+            fromJob l [sourceFile "l"],
+            fromJob d [sourceFile "d"],
+        ],
+        outputs: ["subject"],
+        env: Dict.empty,
+    }
+
+letter : Str -> Job
+letter = \whichLetter ->
+    job {
+        command: exec (systemTool "bash") [
+            "-c",
+            "printf \(whichLetter) > \(whichLetter)",
+        ],
+        inputs: [],
+        outputs: [whichLetter],
+        env: Dict.empty,
+    }
+
+d = letter "d"
+e = letter "e"
+h = letter "h"
+l = letter "l"
+o = letter "o"
+r = letter "r"
+w = letter "w"

--- a/tests/end_to_end/job_inputs_branching/rbt.roc
+++ b/tests/end_to_end/job_inputs_branching/rbt.roc
@@ -36,7 +36,7 @@ greeting =
             "pipefail",
             "-c",
             """
-            H=$(cat h)
+            H=$(cat H)
             E=$(cat e)
             L=$(cat l)
             O=$(cat o)
@@ -45,7 +45,7 @@ greeting =
             """,
         ],
         inputs: [
-            fromJob h [sourceFile "h"],
+            fromJob h [sourceFile "H"],
             fromJob e [sourceFile "e"],
             fromJob l [sourceFile "l"],
             fromJob o [sourceFile "o"],
@@ -62,7 +62,7 @@ subject =
             "pipefail",
             "-c",
             """
-            W=$(cat w)
+            W=$(cat W)
             O=$(cat o)
             R=$(cat r)
             L=$(cat l)
@@ -72,7 +72,7 @@ subject =
             """,
         ],
         inputs: [
-            fromJob w [sourceFile "w"],
+            fromJob w [sourceFile "W"],
             fromJob o [sourceFile "o"],
             fromJob r [sourceFile "r"],
             fromJob l [sourceFile "l"],
@@ -96,8 +96,8 @@ letter = \whichLetter ->
 
 d = letter "d"
 e = letter "e"
-h = letter "h"
+h = letter "H"
 l = letter "l"
 o = letter "o"
 r = letter "r"
-w = letter "w"
+w = letter "W"


### PR DESCRIPTION
Allows jobs to depend on other jobs, making a build graph! Finally! Yay!

Of course, job execution is still single-threaded, but now we can do more-or-less the same jobs as `make --jobs 1`! (Although we don't do the magic dynamic discovery thing that make does.)

Fixes #67
