### PR TITLE
walk the build graph in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        # os: [ubuntu-latest, macos-12]
+        os: [macos-12]
 
     timeout-minutes: 90
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           command: clippy
           args: -- -D warnings
 
+      - name: gen-stub-lib
+        run: roc gen-stub-lib ./examples/hello/rbt.roc
+
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,19 +55,13 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-      - name: make libapp.so via roc build
-        if: startsWith(matrix.os, 'ubuntu')
-        run: roc build ./examples/hello/rbt.roc
-
-      - name: make libapp.so via gen-stub-lib
-        if: startsWith(matrix.os, 'macos')
+      - name: make libapp.so
         run: roc gen-stub-lib ./examples/hello/rbt.roc
 
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -vv
 
   platform-generic:
     name: cargo fmt, roc format, roc check, typos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release
+          args: -vv --release
 
   platform-generic:
     name: cargo fmt, roc format, roc check, typos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,12 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-      - name: gen-stub-lib
+      - name: make libapp.so via roc build
+        if: startsWith(matrix.os, 'ubuntu')
+        run: roc build ./examples/hello/rbt.roc
+
+      - name: make libapp.so via gen-stub-lib
+        if: startsWith(matrix.os, 'macos')
         run: roc gen-stub-lib ./examples/hello/rbt.roc
 
       - name: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: download Roc nightly build (macOS)
         if: startsWith(matrix.os, 'macos')
-        run: ./ci/download_latest_nightly.sh macos_x86_64
+        run: ./ci/download_latest_nightly.sh macos_12_x86_64
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --lib
 
       - name: cargo clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -vv --release
+          args: -vv
 
   platform-generic:
     name: cargo fmt, roc format, roc check, typos

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
 .envrc
 .rbt
+libapp.so
 target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "predicates"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +752,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +820,7 @@ dependencies = [
  "log",
  "notify",
  "path-absolutize",
+ "rand",
  "roc_std",
  "serde",
  "serde_json",
@@ -1001,6 +1049,7 @@ dependencies = [
  "autocfg",
  "bytes",
  "libc",
+ "memchr",
  "mio 0.8.4",
  "num_cpus",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,19 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,31 +859,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "roc-build"
+name = "rbt"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -909,6 +885,30 @@ dependencies = [
  "walkdir",
  "xxhash-rust",
  "zerocopy",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+
+[[package]]
+name = "futures-task"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+
+[[package]]
+name = "futures-util"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +910,7 @@ dependencies = [
  "byteorder",
  "clap",
  "digest",
+ "futures",
  "itertools",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +519,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,7 +538,7 @@ checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log",
- "mio",
+ "mio 0.6.23",
  "slab",
 ]
 
@@ -559,10 +577,20 @@ dependencies = [
  "fsevent-sys",
  "inotify",
  "libc",
- "mio",
+ "mio 0.6.23",
  "mio-extras",
  "walkdir",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -628,6 +656,12 @@ checksum = "d611d5291372b3738a34ebf0d1f849e58b1dcc1101032f76a346eaa1f8ddbb5b"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "predicates"
@@ -745,6 +779,7 @@ dependencies = [
  "simple_logger",
  "sled",
  "tempfile",
+ "tokio",
  "walkdir",
  "xxhash-rust",
  "zerocopy",
@@ -808,6 +843,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -949,6 +993,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
+name = "tokio"
+version = "1.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "mio 0.8.4",
+ "num_cpus",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1051,12 @@ dependencies = [
  "winapi 0.3.9",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,26 +125,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -155,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -454,12 +452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,16 +464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -1111,12 +1093,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ libc = "0.2"
 log = { version = "0.4.17", features = ["max_level_trace", "release_max_level_info"] }
 notify = "4"
 path-absolutize = "3.0.13"
+rand = "0.8.5"
 roc_std = { path = "vendor/roc_std" }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 simple_logger = { version = "2.2.0", features = ["stderr"] }
 sled = "0.34"
 tempfile = "3.2"
-tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "process", "fs", "macros"] }
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "process", "fs", "macros", "io-util"] }
 walkdir = "2.3"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 zerocopy = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ blake3 = "1.3.1"
 byteorder = "1.4"
 clap = { version = "3.2.16", features = ["color", "suggestions", "unstable-v4", "env", "cargo", "derive"] }
 digest = "0.10"
+futures = "0.3.25"
 itertools = "0.10.3"
 libc = "0.2"
 log = { version = "0.4.17", features = ["max_level_trace", "release_max_level_info"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.83"
 simple_logger = { version = "2.2.0", features = ["stderr"] }
 sled = "0.34"
 tempfile = "3.2"
-tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "process", "fs", "macros", "io-util"] }
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "process", "fs", "macros", "io-util", "sync"] }
 walkdir = "2.3"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 zerocopy = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 anyhow = "1.0"
 blake3 = "1.3.1"
 byteorder = "1.4"
-clap = { version = "3.2.16", features = ["color", "suggestions", "unstable-v4", "env", "cargo", "derive"] }
+clap = { version = "4.0.18", features = ["color", "suggestions", "env", "cargo", "derive"] }
 digest = "0.10"
 futures = "0.3.25"
 itertools = "0.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0.83"
 simple_logger = { version = "2.2.0", features = ["stderr"] }
 sled = "0.34"
 tempfile = "3.2"
-tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "process", "fs"] }
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "process", "fs", "macros"] }
 walkdir = "2.3"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 zerocopy = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0.83"
 simple_logger = { version = "2.2.0", features = ["stderr"] }
 sled = "0.34"
 tempfile = "3.2"
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "process", "fs"] }
 walkdir = "2.3"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 zerocopy = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-name = "roc-build"
+name = "rbt"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
+
+links = "app"
 
 [dependencies]
 anyhow = "1.0"
@@ -29,7 +31,12 @@ zerocopy = "0.6"
 
 [lib]
 name = "host"
-crate-type = ["staticlib"]
+path = "src/lib.rs"
+crate-type = ["staticlib", "rlib"]
+
+[[bin]]
+name = "host"
+path = "src/main.rs"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.4", features = ["color-auto"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-lib=dylib=app");
+    println!("cargo:rustc-link-search=.");
+}

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
     println!("cargo:rustc-link-lib=dylib=app");
     println!("cargo:rustc-link-search=.");
+    println!("cargo:rustc-env=LD_LIBRARY_PATH=.");
 }

--- a/host.c
+++ b/host.c
@@ -1,7 +1,3 @@
-#include <stdio.h>
+extern unsigned char rust_main();
 
-extern int rust_main();
-
-int main() {
-  return rust_main();
-}
+int main() { return (int)rust_main(); }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "acdb1726783637852c01e0ad639ac9cbec28d8c8",
-        "sha256": "1wszl8q70z6wfgkh2dvgmhhry6qp9nar421qq2ifd17hq2jj9ck3",
+        "rev": "351d8bc316bf901a81885bab5f52687ec8ccab6e",
+        "sha256": "1yzhz7ihkh6p2sxhp3amqfbmm2yqzaadqqii1xijymvl8alw5rrr",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/acdb1726783637852c01e0ad639ac9cbec28d8c8.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/351d8bc316bf901a81885bab5f52687ec8ccab6e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,22 +17,22 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "abe6ea8ac11de69b7708ca9c70e8cd007600cd73",
-        "sha256": "1cv5hx2gdc8wmyspbz7ahw1p2bg69jfgg3ahxg4b4jvhq4bmy9ya",
+        "rev": "ef2f213d9659a274985778bff4ca322f3ef3ac68",
+        "sha256": "06mis36j5g1lz9ahzy7pcbdlnhw45l6gn2zj605ab3ssim88x17c",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/abe6ea8ac11de69b7708ca9c70e8cd007600cd73.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ef2f213d9659a274985778bff4ca322f3ef3ac68.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "roc": {
-        "branch": "i4077",
+        "branch": "fix-nix-packaging-macos",
         "description": "Roc is a language for making delightful software.",
         "homepage": "https://roc-lang.org",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "8f33bda38bda79adcec8751a06b3fc14f9b86aa9",
-        "sha256": "0wmp574g75ja4gw141sib8gfzvhm10c3pnnbyykzna8z3ixgly3k",
+        "rev": "db8955d6b58345e318e90d232fa22cf48913bbdd",
+        "sha256": "101y42fyjc2mp3pnv0vfnz2qrjckvpdgidrx4vxpdp67ddpw87mx",
         "type": "tarball",
-        "url": "https://github.com/roc-lang/roc/archive/8f33bda38bda79adcec8751a06b3fc14f9b86aa9.tar.gz",
+        "url": "https://github.com/roc-lang/roc/archive/db8955d6b58345e318e90d232fa22cf48913bbdd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
   ];
 
   roc = pkgs.callPackage sources.roc {
-    cargoSha256 = "sha256-bq+s/X3/tIaNa3TAZo9k4/eqozt3y4wcYe9IMbDN0KE=";
+    cargoSha256 = "sha256-Qmriwe+xSL5/pU8oqqj5Qw6H179KYqOljWl0rpPD6MY=";
   };
 in pkgs.mkShell {
   buildInputs = with pkgs;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,7 +57,7 @@ impl Cli {
         let runtime = self.async_runtime()?;
 
         runtime
-            .block_on(coordinator.run_all())
+            .block_on(coordinator.run())
             .context("failed to run jobs")?;
 
         if self.print_root_output_paths {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,7 @@ impl Cli {
         let runtime = self.async_runtime()?;
 
         runtime
-            .block_on(async { coordinator.run_all(runner) })
+            .block_on(coordinator.run_all(runner))
             .context("failed to run jobs")?;
 
         if self.print_root_output_paths {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,7 @@ impl Cli {
         let runtime = self.async_runtime()?;
 
         runtime
-            .block_on(coordinator.run_all(runner))
+            .block_on(coordinator.run_all(&runner))
             .context("failed to run jobs")?;
 
         if self.print_root_output_paths {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,7 @@ impl Cli {
             store,
             db.open_tree("file_hashes")
                 .context("could not open file hashes database")?,
+            self.root_dir.join("workspaces"),
         );
         builder.add_root(&rbt.default);
 
@@ -47,12 +48,10 @@ impl Cli {
             .build()
             .context("could not initialize coordinator")?;
 
-        let runner = crate::runner::Runner::new(self.root_dir.join("workspaces"));
-
         let runtime = self.async_runtime()?;
 
         runtime
-            .block_on(coordinator.run_all(&runner))
+            .block_on(coordinator.run_all())
             .context("failed to run jobs")?;
 
         if self.print_root_output_paths {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,9 @@ pub struct Cli {
     /// than zero.
     #[clap(long, short('j'))]
     max_local_jobs: Option<NonZeroUsize>,
+
+    #[clap(long, default_value = "trace")]
+    pub log_level: log::LevelFilter,
 }
 
 impl Cli {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,9 +43,7 @@ impl Cli {
 
         let runner = crate::runner::Runner::new(self.root_dir.join("workspaces"));
 
-        while coordinator.has_outstanding_work() {
-            coordinator.run_next(&runner).context("failed to run job")?;
-        }
+        coordinator.run_all(runner).context("failed to run jobs")?;
 
         if self.print_root_output_paths {
             for root in coordinator.roots() {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -302,7 +302,7 @@ impl<'roc> Coordinator {
 
         loop {
             tokio::select! {
-                Some(id) = ready_rx.recv() => self.handle_ready(id, done_tx.clone()).await?,
+                Some(id) = ready_rx.recv() => self.run(id, done_tx.clone()).await?,
                 Some(msg) = done_rx.recv() => {
                     self.handle_done(msg, ready_tx.clone()).await?;
 
@@ -314,7 +314,7 @@ impl<'roc> Coordinator {
         }
     }
 
-    async fn handle_ready(&mut self, id: ReadyMsg, done_tx: mpsc::Sender<DoneMsg>) -> Result<()> {
+    async fn run(&mut self, id: ReadyMsg, done_tx: mpsc::Sender<DoneMsg>) -> Result<()> {
         let job = self.jobs.get(&id).context("had a bad job ID")?;
 
         log::debug!("preparing to run job {}", job);

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -265,6 +265,8 @@ impl<'roc> Builder<'roc> {
     }
 }
 
+type DoneMsg = (job::Key<job::Base>, Option<Workspace>);
+
 #[derive(Debug)]
 pub struct Coordinator {
     store: Store,
@@ -289,10 +291,6 @@ pub struct Coordinator {
     ready: Vec<job::Key<job::Base>>,
     running: FuturesUnordered<JoinHandle<Result<DoneMsg>>>,
 }
-
-type DoneMsg = (job::Key<job::Base>, Option<Workspace>);
-
-type ReadyMsg = job::Key<job::Base>;
 
 impl<'roc> Coordinator {
     pub async fn run_all(&mut self) -> Result<()> {
@@ -332,7 +330,7 @@ impl<'roc> Coordinator {
         Ok(())
     }
 
-    async fn start(&mut self, id: ReadyMsg) -> Result<()> {
+    async fn start(&mut self, id: job::Key<job::Base>) -> Result<()> {
         let job = self.jobs.get(&id).context("had a bad job ID")?;
 
         log::debug!("preparing to run job {}", job);

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -295,7 +295,8 @@ pub struct Coordinator {
 }
 
 impl<'roc> Coordinator {
-    pub async fn run_all(&mut self) -> Result<()> {
+    /// Run the build from start to finish.
+    pub async fn run(&mut self) -> Result<()> {
         log::trace!("scheduling immediately-available jobs");
         self.schedule()
             .await
@@ -316,6 +317,9 @@ impl<'roc> Coordinator {
         Ok(())
     }
 
+    /// Start any outstanding work according to our scheduling rules. Right
+    /// now that just means that we won't ever be running more jobs than
+    /// `self.max_local_jobs`.
     async fn schedule(&mut self) -> Result<()> {
         let maximum_schedulable = (self.max_local_jobs - self.running.len()).max(0);
 
@@ -335,6 +339,7 @@ impl<'roc> Coordinator {
         Ok(())
     }
 
+    /// Start and track a single job by ID.
     async fn start(&mut self, id: job::Key<job::Base>) -> Result<()> {
         let job = self.jobs.get(&id).context("had a bad job ID")?;
 

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -272,7 +272,7 @@ impl<'roc> Coordinator {
         let runner = Runner::new(self.workspace_root.clone());
 
         while self.has_outstanding_work() {
-            self.run_next(&runner).context("failed to run job")?;
+            self.run_next(&runner).await.context("failed to run job")?;
         }
 
         Ok(())
@@ -282,7 +282,7 @@ impl<'roc> Coordinator {
         !self.blocked.is_empty() || !self.ready_immediately.is_empty()
     }
 
-    pub fn run_next(&mut self, runner: &Runner) -> Result<()> {
+    pub async fn run_next(&mut self, runner: &Runner) -> Result<()> {
         let id = match self.ready_immediately.pop() {
             Some(id) => id,
             None => anyhow::bail!("no work ready to do"),
@@ -312,6 +312,7 @@ impl<'roc> Coordinator {
             None => {
                 let workspace = runner
                     .run(job, &self.job_to_content_hash)
+                    .await
                     .context("could not run job")?;
 
                 self.job_to_content_hash.insert(

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -265,6 +265,14 @@ pub struct Coordinator<'roc> {
 }
 
 impl<'roc> Coordinator<'roc> {
+    pub fn run_all<R: Runner>(&mut self, runner: R) -> Result<()> {
+        while self.has_outstanding_work() {
+            self.run_next(&runner).context("failed to run job")?;
+        }
+
+        Ok(())
+    }
+
     pub fn has_outstanding_work(&self) -> bool {
         !self.blocked.is_empty() || !self.ready.is_empty()
     }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -321,7 +321,7 @@ impl<'roc> Coordinator {
     /// now that just means that we won't ever be running more jobs than
     /// `self.max_local_jobs`.
     async fn schedule(&mut self) -> Result<()> {
-        let maximum_schedulable = (self.max_local_jobs - self.running.len()).max(0);
+        let maximum_schedulable = self.max_local_jobs.saturating_sub(self.running.len());
 
         // The intent here is to drain a certain number of items from
         // `self.ready`. If the borrowing rules allowed it, we'd drain directly.

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -296,14 +296,12 @@ pub struct Coordinator {
 
 impl<'roc> Coordinator {
     pub async fn run_all(&mut self) -> Result<()> {
-        log::trace!("starting runner loop");
-
+        log::trace!("scheduling immediately-available jobs");
         self.schedule()
             .await
             .context("could not start immediately-ready jobs")?;
 
-        log::trace!("started initial batch of jobs");
-
+        log::trace!("starting coordinator loop");
         while let Some(join_res) = self.running.next().await {
             match join_res {
                 Ok(Ok(done_msg)) => self

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -134,7 +134,7 @@ impl<'roc> Builder<'roc> {
             let key = cache_key.to_db_key();
             if let Some(hash) = self
                 .meta_to_hash
-                .get(&key)
+                .get(key)
                 .context("could not read file hash from database")?
             {
                 coordinator.path_to_hash.insert(
@@ -145,7 +145,7 @@ impl<'roc> Builder<'roc> {
                 continue;
             }
 
-            let mut file = File::open(&path)
+            let mut file = File::open(path)
                 .with_context(|| format!("couldn't open `{}` for hashing.", path.display()))?;
 
             hasher.reset();

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -319,6 +319,7 @@ impl<'roc> Coordinator {
                     job.base_key,
                     self.store
                         .store_from_workspace(final_key, job, workspace)
+                        .await
                         .context("could not store job output")?,
                 );
             }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -74,7 +74,7 @@ impl<'roc> Builder<'roc> {
             // each of which will have at least one leaf node.
             jobs: HashMap::with_capacity(self.roots.len()),
             blocked: HashMap::default(),
-            ready_immediately: Vec::with_capacity(self.roots.len()),
+            ready: Vec::with_capacity(self.roots.len()),
 
             // TODO: clean up bits of state
             runner_builder: RunnerBuilder::new(self.workspace_root.clone()),
@@ -231,7 +231,7 @@ impl<'roc> Builder<'roc> {
                     );
                 }
             } else {
-                coordinator.ready_immediately.push(job.base_key);
+                coordinator.ready.push(job.base_key);
             }
 
             glue_to_job_key.insert(glue_job, job.base_key);
@@ -274,7 +274,7 @@ pub struct Coordinator {
 
     // TODO: should this be calculated based on the keys that are in `jobs` but
     // not in `blocked`?
-    ready_immediately: Vec<job::Key<job::Base>>,
+    ready: Vec<job::Key<job::Base>>,
 
     // TODO: clean up all these bits of state
     runner_builder: RunnerBuilder,
@@ -292,7 +292,7 @@ impl<'roc> Coordinator {
         let (done_tx, mut done_rx) = mpsc::channel::<DoneMsg>(self.jobs.len());
         let (ready_tx, mut ready_rx) = mpsc::channel::<ReadyMsg>(self.jobs.len());
 
-        for starter_id in self.ready_immediately.drain(..) {
+        for starter_id in self.ready.drain(..) {
             ready_tx
                 .send(starter_id)
                 .await

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -31,7 +31,7 @@ impl<'roc> Builder<'roc> {
         self.roots.push(job);
     }
 
-    pub fn build(self) -> Result<Coordinator<'roc>> {
+    pub fn build(self) -> Result<Coordinator> {
         // Here's the overview of what we're about to do: for each file in
         // each target job, we're going to look at metadata for that file and
         // use that metadata to look up the file's hash (if we don't have it
@@ -241,7 +241,7 @@ impl<'roc> Builder<'roc> {
 }
 
 #[derive(Debug)]
-pub struct Coordinator<'roc> {
+pub struct Coordinator {
     store: Store,
 
     roots: Vec<job::Key<job::Base>>,
@@ -255,7 +255,7 @@ pub struct Coordinator<'roc> {
     job_to_content_hash: HashMap<job::Key<job::Base>, store::Item>,
 
     // which jobs should run when?
-    jobs: HashMap<job::Key<job::Base>, Job<'roc>>,
+    jobs: HashMap<job::Key<job::Base>, Job>,
     blocked: HashMap<job::Key<job::Base>, HashSet<job::Key<job::Base>>>,
 
     // TODO: should this be calculated based on the keys that are in `jobs` but
@@ -263,7 +263,7 @@ pub struct Coordinator<'roc> {
     ready_immediately: Vec<job::Key<job::Base>>,
 }
 
-impl<'roc> Coordinator<'roc> {
+impl<'roc> Coordinator {
     pub async fn run_all(&mut self, runner: &Runner) -> Result<()> {
         while self.has_outstanding_work() {
             self.run_next(runner).context("failed to run job")?;

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -265,7 +265,7 @@ pub struct Coordinator<'roc> {
 }
 
 impl<'roc> Coordinator<'roc> {
-    pub fn run_all<R: Runner>(&mut self, runner: R) -> Result<()> {
+    pub async fn run_all<R: Runner>(&mut self, runner: R) -> Result<()> {
         while self.has_outstanding_work() {
             self.run_next(&runner).context("failed to run job")?;
         }

--- a/src/glue.rs
+++ b/src/glue.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(clippy::needless_borrow)]
 #![allow(clippy::clone_on_copy)]
+#![allow(clippy::explicit_auto_deref)]
 
 #[cfg(any(
     target_arch = "arm",

--- a/src/job.rs
+++ b/src/job.rs
@@ -258,9 +258,9 @@ impl Hash for Command {
     }
 }
 
-impl From<&Command> for std::process::Command {
+impl From<&Command> for tokio::process::Command {
     fn from(job_command: &Command) -> Self {
-        let mut command = std::process::Command::new(job_command.tool.as_str());
+        let mut command = tokio::process::Command::new(job_command.tool.as_str());
 
         for arg in &job_command.args {
             command.arg(arg.as_str());

--- a/src/job.rs
+++ b/src/job.rs
@@ -301,4 +301,16 @@ mod test {
             job.base_key
         );
     }
+
+    fn assert_send<T: Send>() {}
+
+    // we've had Job need to be sendable on and off throughout rbt's
+    // development, and it's always been a hassle to get it re-sendable when
+    // we temporarily relax the restriction. So this is a kind of weird test,
+    // and we may not always need it, but it should at least prevent us from
+    // backsliding again.
+    #[test]
+    fn job_is_sendable() {
+        assert_send::<Job>()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub fn rust_main() -> isize {
 
     simple_logger::SimpleLogger::new()
         .with_module_level("sled", log::LevelFilter::Info)
+        .with_level(cli.log_level)
         .init()
         .expect("failed to initialize logger");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod cli;
 mod coordinator;
 mod glue;
 mod job;
+mod path_meta_key;
 mod runner;
 mod store;
 mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(host::rust_main() as _);
+}

--- a/src/path_meta_key.rs
+++ b/src/path_meta_key.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+use std::convert::TryFrom;
+use std::fs::Metadata;
+use std::hash::{Hash, Hasher};
+use std::time::SystemTime;
+use xxhash_rust::xxh3::Xxh3;
+
+#[cfg(target_family = "unix")]
+use std::os::unix::fs::MetadataExt;
+
+#[derive(Debug, Hash)]
+pub struct PathMetaKey {
+    // common
+    modified: SystemTime,
+    len: u64,
+
+    // Unix-only
+    #[cfg(target_family = "unix")]
+    inode: u64,
+    #[cfg(target_family = "unix")]
+    mode: u32,
+    #[cfg(target_family = "unix")]
+    uid: u32,
+    #[cfg(target_family = "unix")]
+    gid: u32,
+    // TODO: extra info for Windows
+}
+
+impl PathMetaKey {
+    pub fn to_db_key(&self) -> [u8; 8] {
+        let mut hasher = Xxh3::new();
+        self.hash(&mut hasher);
+
+        hasher.finish().to_le_bytes()
+    }
+}
+
+#[cfg(target_family = "unix")]
+impl TryFrom<Metadata> for PathMetaKey {
+    type Error = anyhow::Error;
+
+    fn try_from(meta: Metadata) -> Result<PathMetaKey> {
+        Ok(PathMetaKey {
+            modified: meta
+                .modified()
+                .context("mtime is not supported on this system")?,
+            len: meta.len(),
+            inode: meta.ino(),
+            mode: meta.mode(),
+            uid: meta.uid(),
+            gid: meta.gid(),
+        })
+    }
+}
+
+#[cfg(not(target_family = "unix"))]
+impl TryFrom<Metadata> for PathMetaKey {
+    type Error = anyhow::Error;
+
+    fn try_from(meta: Metadata) -> Result<PathMetaKey> {
+        Ok(PathMetaKey {
+            modified: meta
+                .modified()
+                .context("mtime is not supported on this system")?,
+            len: meta.len(),
+        })
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -24,10 +24,12 @@ impl Runner {
         job_to_content_hash: &HashMap<job::Key<job::Base>, store::Item>,
     ) -> Result<Workspace> {
         let workspace = Workspace::create(&self.workspace_root, &job.base_key)
+            .await
             .with_context(|| format!("could not create workspace for {}", job))?;
 
         workspace
             .set_up_files(job, job_to_content_hash)
+            .await
             .with_context(|| format!("could not set up workspace files for {}", job))?;
 
         let mut command = Command::from(&job.command);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,7 +4,7 @@ use crate::workspace::Workspace;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::process::Command;
+use tokio::process::Command;
 
 #[derive(Debug)]
 pub struct Runner {
@@ -41,6 +41,7 @@ impl Runner {
             .spawn()
             .context("could not run command")?
             .wait()
+            .await
             .context("command wasn't running")?;
 
         match status.code() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -18,7 +18,7 @@ impl Runner {
 }
 
 impl Runner {
-    pub fn run(
+    pub async fn run(
         &self,
         job: &Job,
         job_to_content_hash: &HashMap<job::Key<job::Base>, store::Item>,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -30,7 +30,7 @@ impl Runner {
             .set_up_files(job, job_to_content_hash)
             .with_context(|| format!("could not set up workspace files for {}", job))?;
 
-        let mut command: Command = job.into();
+        let mut command = Command::from(&job.command);
         command.current_dir(&workspace);
 
         // TODO: send stdout, stderr, etc to The Log Zone(tm)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,4 +1,3 @@
-use crate::coordinator;
 use crate::job::{self, Job};
 use crate::store;
 use crate::workspace::Workspace;
@@ -18,8 +17,8 @@ impl Runner {
     }
 }
 
-impl coordinator::Runner for Runner {
-    fn run(
+impl Runner {
+    pub fn run(
         &self,
         job: &Job,
         job_to_content_hash: &HashMap<job::Key<job::Base>, store::Item>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -83,7 +83,7 @@ impl Store {
 #[derive(Debug)]
 struct ItemBuilder<'job> {
     workspace: Workspace,
-    job: &'job Job<'job>,
+    job: &'job Job,
     item: Item,
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -213,8 +213,8 @@ impl<'job> ItemBuilder<'job> {
             // we only move things into the store if the job succeeded, so
             // we'll be removing everything in it shortly anyway!
             log::trace!("moving `{}` into store path", &output.display());
-            let out = temp.join(&output);
-            fs::rename(self.workspace.join(&output), &out)
+            let out = temp.join(output);
+            fs::rename(self.workspace.join(output), &out)
                 .await
                 .with_context(|| {
                     format!(
@@ -234,7 +234,7 @@ impl<'job> ItemBuilder<'job> {
         // Now that we're all done moving files over and making them read-only,
         // we can safely make all the directories read-only too.
         for dir in &created_dirs {
-            Self::make_readonly(&temp.join(&dir))
+            Self::make_readonly(&temp.join(dir))
                 .await
                 .with_context(|| {
                     format!("could not make `{}` read-only in the store", dir.display(),)

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -119,7 +119,7 @@ mod tests {
         job::Key::default()
     }
 
-    fn glue_job_with_files<'roc>(files: &[&str]) -> glue::Job {
+    fn glue_job_with_files(files: &[&str]) -> glue::Job {
         glue::Job::Job(glue::R1 {
             command: glue::Command {
                 tool: glue::Tool::SystemTool(glue::SystemToolPayload {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -2,11 +2,8 @@ use crate::{job, store};
 use anyhow::{Context, Result};
 use path_absolutize::Absolutize;
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
-
-#[cfg(target_family = "unix")]
-use std::os::unix::fs::symlink;
+use tokio::fs;
 
 #[cfg(target_family = "windows")]
 use std::os::windows::fs::symlink_file;
@@ -15,7 +12,7 @@ use std::os::windows::fs::symlink_file;
 pub struct Workspace(PathBuf);
 
 impl Workspace {
-    pub fn create<Finality>(root: &Path, key: &job::Key<Finality>) -> Result<Self> {
+    pub async fn create<Finality>(root: &Path, key: &job::Key<Finality>) -> Result<Self> {
         let workspace = Workspace(root.join(key.to_string()));
 
         std::fs::create_dir_all(&workspace.0).context("could not create workspace")?;
@@ -23,13 +20,13 @@ impl Workspace {
         Ok(workspace)
     }
 
-    pub fn set_up_files(
+    pub async fn set_up_files(
         &self,
         job: &job::Job,
         job_to_store_path: &HashMap<job::Key<job::Base>, store::Item>,
     ) -> Result<()> {
         for file in &job.input_files {
-            self.set_up_path(file, file)?
+            self.set_up_path(file, file).await?
         }
 
         for (key, files) in &job.input_jobs {
@@ -37,18 +34,21 @@ impl Workspace {
                 .get(key)
                 .with_context(|| format!("could not find a store path for job {}", key))?;
 
+            // TODO: could we spawn all these in parallel? Seems like we could,
+            // but creating parent directories in parallel may cause contention
+            // issues.
             for file in files {
-                self.set_up_path(&store_item.join(file), file)?
+                self.set_up_path(&store_item.join(file), file).await?
             }
         }
 
         Ok(())
     }
 
-    fn set_up_path(&self, src: &Path, dest: &Path) -> Result<()> {
+    async fn set_up_path(&self, src: &Path, dest: &Path) -> Result<()> {
         // validate that the path exists and is a file
-        let meta = src
-            .metadata()
+        let meta = fs::metadata(src)
+            .await
             .with_context(|| format!("`{}` does not exist", dest.display()))?;
 
         if meta.is_dir() {
@@ -63,6 +63,7 @@ impl Workspace {
 
             if !parent.exists() {
                 fs::create_dir_all(parent)
+                    .await
                     .with_context(|| format!("could not create parent for `{}`", dest.display()))?;
             }
         }
@@ -72,11 +73,13 @@ impl Workspace {
         })?;
 
         #[cfg(target_family = "unix")]
-        symlink(absolute_src, self.join(dest))
+        fs::symlink(absolute_src, self.join(dest))
+            .await
             .with_context(|| format!("could not symlink `{}` into workspace", dest.display()))?;
 
         #[cfg(target_family = "windows")]
-        symlink_file(absolute_src, workspace.join(dest))
+        fs::symlink_file(absolute_src, workspace.join(dest))
+            .await
             .with_context(|| format!("could not symlink `{}` into workspace", file.display()))?;
 
         Ok(())
@@ -88,6 +91,9 @@ impl Workspace {
 }
 
 impl Drop for Workspace {
+    // TODO: measure and see if blocking on these drops is affecting
+    // performance, and consider moving this to a cleanup function that we call
+    // by hand.
     fn drop(&mut self) {
         if let Err(problem) = std::fs::remove_dir_all(&self.0) {
             log::warn!("problem removing workspace dir: {}", problem);
@@ -132,11 +138,13 @@ mod tests {
         })
     }
 
-    #[test]
-    fn sets_up_and_tears_down() {
+    #[tokio::test]
+    async fn sets_up_and_tears_down() {
         let temp = TempDir::new().unwrap();
 
-        let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
+        let workspace = Workspace::create(temp.path(), &key())
+            .await
+            .expect("could not create workspace");
         let path = workspace.as_ref().to_path_buf();
 
         assert!(path.is_dir());
@@ -146,15 +154,18 @@ mod tests {
         assert!(!path.exists());
     }
 
-    #[test]
-    fn test_sets_up_file() {
+    #[tokio::test]
+    async fn test_sets_up_file() {
         let temp = TempDir::new().unwrap();
-        let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
+        let workspace = Workspace::create(temp.path(), &key())
+            .await
+            .expect("could not create workspace");
 
         let glue_job = glue_job_with_files(&[file!()]);
         let job = job::Job::from_glue(&glue_job, &HashMap::new()).unwrap();
         workspace
             .set_up_files(&job, &HashMap::new())
+            .await
             .expect("failed to set up files");
 
         let path = workspace.join(file!());
@@ -166,11 +177,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_rejects_missing_file() {
+    #[tokio::test]
+    async fn test_rejects_missing_file() {
         let temp = TempDir::new().unwrap();
 
-        let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
+        let workspace = Workspace::create(temp.path(), &key())
+            .await
+            .expect("could not create workspace");
         let glue_job = glue_job_with_files(&["does-not-exist"]);
         let job = job::Job::from_glue(&glue_job, &HashMap::new()).unwrap();
 
@@ -178,15 +191,18 @@ mod tests {
             String::from("`does-not-exist` does not exist"),
             workspace
                 .set_up_files(&job, &HashMap::new())
+                .await
                 .unwrap_err()
                 .to_string(),
         )
     }
 
-    #[test]
-    fn test_rejects_directory() {
+    #[tokio::test]
+    async fn test_rejects_directory() {
         let temp = TempDir::new().unwrap();
-        let workspace = Workspace::create(temp.path(), &key()).expect("could not create workspace");
+        let workspace = Workspace::create(temp.path(), &key())
+            .await
+            .expect("could not create workspace");
 
         // currently, `file!()` gives us `src/workspace.rs`. This works for us at
         // the moment, but all we really need is a path containing a directory.
@@ -203,6 +219,7 @@ mod tests {
             ),
             workspace
                 .set_up_files(&job, &HashMap::new())
+                .await
                 .unwrap_err()
                 .to_string()
         );

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -12,7 +12,6 @@ fn output_of_default_job(root: &TempDir, rbt_dot_roc: &Path) -> Result<PathBuf> 
 
     let output = std::process::Command::new("roc")
         .arg("run")
-        .arg("--linker=legacy")
         .arg(filename)
         .arg("--")
         .arg("--root-dir")


### PR DESCRIPTION
This makes `Coordinator` walk the build graph in parallel.

After some discussion on Zulip, I did this with async Rust instead of spawning threads directly. I think this could still use some improvement, but it works well for now. We can tune it with tokio-console or something soon!