### PR TITLE
Empty out environment before running a job

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use itertools::Itertools;
 use roc_std::{RocDict, RocStr};
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::fmt::{self, Display};
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::marker::PhantomData;
@@ -192,6 +193,19 @@ impl<'roc> Job<'roc> {
 impl<'roc> From<&Job<'roc>> for Command {
     fn from(job: &Job) -> Self {
         let mut command = Command::new(&job.command.tool.as_SystemTool().name.to_string());
+
+        let home = env::vars()
+            .find_map(|(var_name, var_value)| {
+                if var_name == "HOME" {
+                    Some(var_value)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+
+        command.env_clear();
+        command.env("HOME", home);
 
         for arg in &job.command.args {
             command.arg(arg.as_str());

--- a/tests/end_to_end/env_cleanup/rbt.roc
+++ b/tests/end_to_end/env_cleanup/rbt.roc
@@ -1,0 +1,20 @@
+app "build"
+    packages { pf: "../../../Package-Config.roc" }
+    imports [pf.Rbt.{ Rbt, systemTool, Job, job, exec }]
+    provides [init] to pf
+
+init : Rbt
+init =
+    Rbt.init { default: hello }
+
+hello : Job
+hello =
+    job {
+        command: exec (systemTool "bash") [
+            "-c",
+            "echo $(printenv) > out",
+        ],
+        inputs: [],
+        outputs: ["out"],
+        env: Dict.empty
+    }


### PR DESCRIPTION
This PR cleans up the environment variables before running a job, which fixes #63.
For now, we're keeping the `HOME` as suggested in the comment.