### PR TITLE
ADR #10: log handling

### DIFF
--- a/ci/download_latest_nightly.sh
+++ b/ci/download_latest_nightly.sh
@@ -18,7 +18,7 @@ fi
 
 RELEASE_FILES="$(echo "$RELEASE_JSON" | jq --raw-output '.assets | map(.browser_download_url) | join("\n")')"
 
-for DAYS_AGO in 0 1 2 3 4; do
+for DAYS_AGO in $(seq 0 14); do
   case "$(uname -s)" in
     Darwin) TARGET_DATE="$(date -v "-${DAYS_AGO}d" '+%Y-%m-%d')";;
     *) TARGET_DATE="$(date --date "${DAYS_AGO} days ago" '+%Y-%m-%d')";;

--- a/docs/adrs/010-logs.md
+++ b/docs/adrs/010-logs.md
@@ -1,20 +1,20 @@
-# ADR 010: What to do with logs?
+# ADR 010: What to do with job stdout/stderr?
 
-**Problem:** when commands fail, you usually want to look at the process logs to see what went wrong.
-You also might want to see logs as the system is building.
+**Problem:** when jobs fail, you usually want to look at stdout or stderr to see what went wrong.
+You also might want to see these logs as the system is building.
 This is more complicated than just "ok, so stream them" because we plan to add remote builders.
-How do we persist logs so you can look at them later, for example when a CI job fails?
+How do we persist stdout and stderr so you can look at them later, for example when a CI job fails?
 
-It seems like the best solution would be to have both a log store and a log sink.
+It seems like the best solution would be to have both a store and a sink.
 Specifically:
 
-1. during evaluation of jobs, logs can be streamed.
+1. during evaluation of jobs, stdout and stderr can be streamed.
    This would let us show them in the CLI or in a web UI.
-2. Logs could be stored like job artifacts in the content-addressable store.
+2. Stdout and stderr could be stored like job artifacts in the content-addressable store.
 
 Part 1 can be implemented today, but part two needs a little bit more groundwork.
-Specifically, how do you keep track of which logs came from which jobs?
-You could store them with the artifacts, but that seems unreasonable in the case of failing jobs (since it would be unreasonable to store artifacts for a failing job.)
+Specifically, how do you keep track of which set of logs came from which jobs?
+You could store them with the artifacts, but that seems unreasonable in the case of failing jobs (since it would be unreasonable to store artifacts for a failing job, but you *do* want stdout and stderr)
 
 Instead, it seems like we need the concept of an invocation, which could keep track of which jobs it did and didn't build, along with log outputs.
 Then, the invocation (along with metadata, logs, and anything else) could be stored in the content-addressable store.

--- a/docs/adrs/010-logs.md
+++ b/docs/adrs/010-logs.md
@@ -1,0 +1,35 @@
+# ADR 010: What to do with logs?
+
+**Problem:** when commands fail, you usually want to look at the process logs to see what went wrong.
+You also might want to see logs as the system is building.
+This is more complicated than just "ok, so stream them" because we plan to add remote builders.
+How do we persist logs so you can look at them later, for example when a CI job fails?
+
+It seems like the best solution would be to have both a log store and a log sink.
+Specifically:
+
+1. during evaluation of jobs, logs can be streamed.
+   This would let us show them in the CLI or in a web UI.
+2. Logs could be stored like job artifacts in the content-addressable store.
+
+Part 1 can be implemented today, but part two needs a little bit more groundwork.
+Specifically, how do you keep track of which logs came from which jobs?
+You could store them with the artifacts, but that seems unreasonable in the case of failing jobs (since it would be unreasonable to store artifacts for a failing job.)
+
+Instead, it seems like we need the concept of an invocation, which could keep track of which jobs it did and didn't build, along with log outputs.
+Then, the invocation (along with metadata, logs, and anything else) could be stored in the content-addressable store.
+
+That means that if you invoke a job remotely, the result could be streamed back to you, or you could download it for easy inspection.
+To start with, the structure could look like:
+
+```
+some-invocation
+└── logs
+    └── some-job-hash
+        ├── stderr.log
+        └── stdout.log
+```
+
+... replacing `some-invocation` with the invocation hash, and `some-job-hash` with the job hash.
+
+We'll surely fill this tree out with interesting things, so it makes sense to leave room for additional hierarchy.


### PR DESCRIPTION
I've been trying to think through how we handle logs. We have a couple different cases we need to handle. I think it needs a little more structure than we have right now, so here's an ADR to talk about that.

I'd like feedback on:

- other than CLI/UI streaming, where else would it make sense to stream logs?
- are there any cases in which collecting all the logs for an invocation wouldn't make sense?