### PR TITLE
re-enable linux in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,13 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-      - name: make libapp.so
+      - name: make libapp.so (macOS)
+        if: startsWith(matrix.os, 'macos')
         run: roc gen-stub-lib ./examples/hello/rbt.roc
+
+      - name: make libapp.so (linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: roc build --lib ./examples/hello/rbt.roc
 
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-12]
-        os: [macos-12]
+        os: [ubuntu-latest, macos-12]
 
     timeout-minutes: 90
     env:

--- a/ci/download_latest_nightly.sh
+++ b/ci/download_latest_nightly.sh
@@ -18,7 +18,7 @@ fi
 
 RELEASE_FILES="$(echo "$RELEASE_JSON" | jq --raw-output '.assets | map(.browser_download_url) | join("\n")')"
 
-for DAYS_AGO in 0 1 2 3 4; do
+for DAYS_AGO in $(seq 0 14); do
   case "$(uname -s)" in
     Darwin) TARGET_DATE="$(date -v "-${DAYS_AGO}d" '+%Y-%m-%d')";;
     *) TARGET_DATE="$(date --date "${DAYS_AGO} days ago" '+%Y-%m-%d')";;


### PR DESCRIPTION
This re-enables Linux in CI, which may reproduce the "phentsize is too big" bug.

@bhansconnect I'm actually really not sure how to minimize this example. Do you have any ideas how we could do that to narrow down what's causing this bug? (Assuming this PR fails, of course.)