### PR TITLE
Fix hash utf8 problem

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -139,7 +139,9 @@ impl<'roc> Builder<'roc> {
             {
                 coordinator.path_to_hash.insert(
                     path.to_path_buf(),
-                    std::str::from_utf8(hash.as_ref())?.into(),
+                    std::str::from_utf8(hash.as_ref())
+                        .with_context(|| format!("could not convert hash `{:?}` from UTF-8", hash))?
+                        .into(),
                 );
 
                 continue;

--- a/src/job.rs
+++ b/src/job.rs
@@ -160,7 +160,7 @@ impl Job {
 
     pub fn final_key(
         &self,
-        path_to_hash: &HashMap<PathBuf, String>,
+        path_to_hash: &HashMap<PathBuf, blake3::Hash>,
         job_to_content_hash: &HashMap<Key<Base>, store::Item>,
     ) -> Result<Key<Final>> {
         let mut hasher = Xxh3::new();


### PR DESCRIPTION
We've been lucky so far that the hashes are accidentally also valid utf8 strings. That luck ran out today! Fortunately, it's easy enough to get a `blake3::Hash` back and just use that as the mapped value, plus it's actually correct!