### PR TITLE
warn about files being written to HOME

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -8,10 +8,10 @@ use anyhow::{Context, Result};
 use core::convert::TryInto;
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Read;
 use std::num::NonZeroUsize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::task::JoinHandle;
 use xxhash_rust::xxh3::Xxh3Builder;
 
@@ -423,6 +423,10 @@ impl<'roc> Coordinator {
             .context("could not retrieve final cache key; was it calculated in `start`?")?;
 
         if let Some(workspace) = workspace_opt {
+            self.check_nothing_was_in_home(&workspace.home_dir())
+                .await
+                .context("could not check for leftover files in HOME")?;
+
             self.job_to_content_hash.insert(
                 job.base_key,
                 self.store
@@ -465,5 +469,19 @@ impl<'roc> Coordinator {
 
     pub fn store_path(&self, key: &job::Key<job::Base>) -> Option<&store::Item> {
         self.job_to_content_hash.get(key)
+    }
+
+    async fn check_nothing_was_in_home(&self, home_dir: &Path) -> Result<()> {
+        for entry in fs::read_dir(home_dir)
+            .with_context(|| format!("could not read `{}`", home_dir.display()))?
+        {
+            // TODO: eventually, we'll collect these and report them per-job
+            log::warn!(
+                "there was a leftover file ({}) in the home directory",
+                entry.context("could not read entry")?.path().display()
+            );
+        }
+
+        Ok(())
     }
 }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -477,7 +477,7 @@ impl<'roc> Coordinator {
         {
             // TODO: eventually, we'll collect these and report them per-job
             log::warn!(
-                "there was a leftover file ({}) in the home directory",
+                "there was a leftover file in the home directory. (`{}`) Did your job write to $HOME?",
                 entry.context("could not read entry")?.path().display()
             );
         }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -423,7 +423,7 @@ impl<'roc> Coordinator {
             .context("could not retrieve final cache key; was it calculated in `start`?")?;
 
         if let Some(workspace) = workspace_opt {
-            self.check_nothing_was_in_home(&workspace.home_dir())
+            self.check_nothing_was_in_home(workspace.home_dir())
                 .await
                 .context("could not check for leftover files in HOME")?;
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -34,6 +34,7 @@ impl RunnerBuilder {
 
         let mut command = Command::from(&job.command);
         command.current_dir(&workspace);
+        command.env("HOME", workspace.home_dir());
 
         Ok(Runner { command, workspace })
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -102,12 +102,14 @@ impl<'job> ItemBuilder<'job> {
                 None => anyhow::bail!("got a non-unicode path `{}`, but Roc should never have produced a Str with invalid unicode.", path.display()),
             };
 
-            let mut file = File::open(&workspace.join(path)).await.with_context(|| {
-                format!(
-                    "couldn't open `{}` for hashing. Did the build produce it?",
-                    path.display()
-                )
-            })?;
+            let mut file = File::open(&workspace.join_build(path))
+                .await
+                .with_context(|| {
+                    format!(
+                        "couldn't open `{}` for hashing. Did the build produce it?",
+                        path.display()
+                    )
+                })?;
 
             // Blake3 is designed to take advantage of SIMD instructions when
             // buffer size is 16KiB or more
@@ -214,7 +216,7 @@ impl<'job> ItemBuilder<'job> {
             // we'll be removing everything in it shortly anyway!
             log::trace!("moving `{}` into store path", &output.display());
             let out = temp.join(output);
-            fs::rename(self.workspace.join(output), &out)
+            fs::rename(self.workspace.join_build(output), &out)
                 .await
                 .with_context(|| {
                     format!(

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -133,7 +133,7 @@ impl Drop for Workspace {
 
 impl AsRef<Path> for Workspace {
     fn as_ref(&self) -> &Path {
-        &self.root
+        &self.build_root
     }
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -11,7 +11,7 @@ use std::os::windows::fs::symlink_file;
 #[derive(Debug)]
 pub struct Workspace {
     root: PathBuf,
-    build_dir: PathBuf,
+    build_root: PathBuf,
     home_dir: PathBuf,
 }
 
@@ -19,12 +19,12 @@ impl Workspace {
     pub async fn create<Finality>(root: &Path, key: &job::Key<Finality>) -> Result<Self> {
         let root = root.join(key.to_string());
         let workspace = Workspace {
-            build_dir: root.join("build"),
+            build_root: root.join("build"),
             home_dir: root.join("home"),
             root,
         };
 
-        std::fs::create_dir_all(&workspace.build_dir)
+        std::fs::create_dir_all(&workspace.build_root)
             .context("could not create workspace build directory")?;
 
         std::fs::create_dir(&workspace.home_dir)
@@ -116,7 +116,7 @@ impl Workspace {
     }
 
     pub fn join_build<P: AsRef<Path>>(&self, other: P) -> PathBuf {
-        self.build_dir.join(other)
+        self.build_root.join(other)
     }
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -118,6 +118,10 @@ impl Workspace {
     pub fn join_build<P: AsRef<Path>>(&self, other: P) -> PathBuf {
         self.build_root.join(other)
     }
+
+    pub fn home_dir(&self) -> &Path {
+        &self.home_dir
+    }
 }
 
 impl Drop for Workspace {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -99,7 +99,7 @@ fn test_cleanup() {
 
     // This are built-ins environment variables from the shell, and are generated every time we run a command
     // Once we add support to save a command's stdout instead of using a shell for everything, this can be removed from the tests
-    let expected_variables = HashSet::from(["_", "PWD", "SHLVL"]);
+    let expected_variables = HashSet::from(["_", "PWD", "SHLVL", "HOME"]);
 
     assert_eq!(expected_variables, variables)
 }


### PR DESCRIPTION
As part of isolating environment variables, we've added a fake `HOME`. This means that tools that write to `HOME` will now get warnings. Eventually, we want to collect these warnings (and once we have caches, turn them into errors) since writing to `HOME` usually indicates that a tool is expecting to either find some configuration or a cache later. This also gives authors of jobs a place to put configuration outside the working directory of the job, if need be (although that's not an intentional part of the design.)

Paired on this with @lindsaykwardell

Fixes #62 